### PR TITLE
Initial Windows plugin

### DIFF
--- a/Posh-ACME/DnsPlugins/Windows-Readme.md
+++ b/Posh-ACME/DnsPlugins/Windows-Readme.md
@@ -41,8 +41,21 @@ Do not proceed until you can successfully establish a CimSession from the client
 
 ### Permissions
 
-TODO
+Setting permissions on Windows DNS depends on whether the DNS zones are integrated with Active Directory or not. Standalone non-domain joined DNS servers don't really have granular permissions as far as I can tell. The user must be local administrator. AD integrated servers can usually set more granular permissions on a per-zone level or better. Suffice it to say, the account being used to connect must have adequate permissions to add and delete TXT records in the associated zone(s).
 
 ## Using the Plugin
 
-TODO
+In a domain joined environment, the only required parameter is the hostname or IP of the DNS server unless you want the module to use different credentials than what PowerShell is running as. In that case, you would specify credentials and optionally the `-WinUseSSL` switch. Both of those tend to be required for non-domain joined servers.
+
+```powershell
+# domain joined environment, no credentials or SSL needed
+New-PACertificate test.example.com -DnsPlugin Windows -PluginArgs @{WinServer='dns1.example.com'}
+
+# standalone environment, adding credentials and SSL flag
+$pArgs = @{WinServer='dns1.example.com'; WinCred=(Get-Credential); WinUseSSL=$true}
+New-PACertificate test.example.com -DnsPlugin Windows -PluginArgs $pArgs
+```
+
+## Advanced Features
+
+Some of the newer features of Windows DNS such as DNS Scopes and VirtualizationInstances are not currently supported in this plugin. If you use those features and need them supported, please submit an [issue](https://github.com/rmbolger/Posh-ACME/issues) describing your environment.

--- a/Posh-ACME/DnsPlugins/Windows-Readme.md
+++ b/Posh-ACME/DnsPlugins/Windows-Readme.md
@@ -1,0 +1,48 @@
+# How To Use the Windows DNS Plugin
+
+This plugin works against the Microsoft Windows DNS server. It doesn't matter whether it's hosted on-premises or in the cloud, physical or virtual, domain joined or standalone. As long as it can be managed via the standard [DnsServer PowerShell module](https://docs.microsoft.com/en-us/powershell/module/dnsserver), it should be supported. This does **not** work against [Azure DNS](https://azure.microsoft.com/en-us/services/dns/). Use the Azure plugin for that.
+
+## Setup
+
+### DnsServer module
+
+The client machine running Posh-ACME must have the `DnsServer` PowerShell module installed. On Windows Server OSes, this can be installed from Server Manager or via PowerShell as follows.
+
+```powershell
+Install-WindowsFeature RSAT-DNS-Server
+```
+
+On Windows client OSes, you will need to download and install the appropriate Remote Server Administration Tools (RSAT) for your OS. The installers are historically OS specific. Here are links for [Windows 10](https://www.microsoft.com/en-us/download/details.aspx?id=45520), [Windows 8.1](https://www.microsoft.com/en-us/download/details.aspx?id=39296), [Windows 8](https://www.microsoft.com/en-us/download/details.aspx?id=28972), and [Windows 7](https://www.microsoft.com/en-us/download/details.aspx?id=7887).
+
+*Warning: The vast majority of testing for this plugin was done on Windows 10 and Windows Server 2016. Please submit [issues](https://github.com/rmbolger/Posh-ACME/issues) if you run into problems on downlevel OSes.*
+
+### PSRemoting and New-CimSession
+
+The DnsServer module relies on PowerShell remoting via `New-CimSession` to establish a remote connection to the DNS server. Depending on your environment, PSRemoting might already be enabled. If not, you need to make sure it is working between your client and DNS server before trying to use Posh-ACME.
+
+Typically, the easiest environment to get things working has both client and server domain joined to the same Active Directory or different domains where the client's domain credentials are trusted by the server's AD. In this case, you can try the following to test from the client machine.
+
+```powershell
+# test in the context of the current process (current user)
+$cs = New-CimSession -ComputerName dnsserver.example.com
+
+# test in the context of a different user
+$cs = New-CimSession -ComputerName dnsserver.example.com -Credential (Get-Credential)
+```
+
+In environments where one or both of the client and server are not domain joined, you may need to explicitly connect via HTTPS. This may involve extra steps during setup to enable an HTTPS listener on the server. Here is a [decent guide](https://4sysops.com/archives/powershell-remoting-over-https-with-a-self-signed-ssl-certificate/) on getting things setup with a self-signed certificate, though a trusted certificate would work as well. And here is how to test from the client machine.
+
+```powershell
+$so = New-CimSessionOption -UseSsl
+$cs = New-CimSession -ComputerName dnsserver.example.com -Credential (Get-Credential) -SessionOptions $so
+```
+
+Do not proceed until you can successfully establish a CimSession from the client to the DNS server.
+
+### Permissions
+
+TODO
+
+## Using the Plugin
+
+TODO

--- a/Posh-ACME/DnsPlugins/Windows.ps1
+++ b/Posh-ACME/DnsPlugins/Windows.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules DnsServer
+#Requires -Modules DnsServer, CimCmdlets
 
 function Add-DnsTxtWindows {
     [CmdletBinding()]
@@ -7,9 +7,39 @@ function Add-DnsTxtWindows {
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
         [string]$TxtValue,
+        [Parameter(Mandatory,Position=2)]
+        [string]$WinServer,
+        [Parameter(Position=3)]
+        [pscredential]$WinCred,
+        [switch]$WinUseSSL,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
+
+    $cim = Connect-WinDns @PSBoundParameters
+    Write-Verbose "Connected to $WinServer"
+
+    $dnsParams = @{ ComputerName=$WinServer; CimSession=$cim }
+
+    Write-Debug "Attempting to find zone for $RecordName"
+    if (!($zoneName = Find-WinZone $RecordName $dnsParams)) {
+        throw "Unable to find zone for $RecordName"
+    }
+    $zone = Get-DnsServerZone $zoneName @dnsParams -EA Stop
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName.Replace(".$ZoneName",'')
+
+    $recs = @($zone | Get-DnsServerResourceRecord -Name $recShort -RRType Txt -EA SilentlyContinue)
+
+    if ($recs.Count -eq 0 -or $TxtValue -notin $recs.RecordData.DescriptiveText) {
+        # create new
+        Write-Verbose "Adding a TXT record for $RecordName with value $TxtValue"
+        $zone | Add-DnsServerResourceRecord -Txt -Name $recShort -DescriptiveText $TxtValue -TimeToLive 00:00:10
+    } else {
+        # nothing to do
+        Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
+    }
 
     <#
     .SYNOPSIS
@@ -24,13 +54,27 @@ function Add-DnsTxtWindows {
     .PARAMETER TxtValue
         The value of the TXT record.
 
+    .PARAMETER WinServer
+        The hostname or IP address of the Windows DNS server.
+
+    .PARAMETER WinCred
+        Credentials with permissions to modify TXT records in the specified zone. This is optional if the current user has the proper permissions already.
+
+    .PARAMETER WinUseSSL
+        Forces the PowerShell remoting session to run over HTTPS. Requires the server have a valid certificate that is installed and trusted by the client or added to the client's TrustedHosts list. This is primarily used when connecting to a non-domain joined DNS server.
+
     .PARAMETER ExtraParams
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
 
     .EXAMPLE
-        Add-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678'
+        Add-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678' -WinServer 'dns1.example.com'
 
-        Adds a TXT record for the specified site with the specified value.
+        Adds a TXT record using the credentials of the calling process.
+
+    .EXAMPLE
+        Add-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678' -WinServer 'dns1.example.com' -WinCred (Get-Credential) -WinUseSSL
+
+        Adds a TXT record using explicit credentials and connecting over HTTPS.
     #>
 }
 
@@ -41,9 +85,40 @@ function Remove-DnsTxtWindows {
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
         [string]$TxtValue,
+        [Parameter(Mandatory,Position=2)]
+        [string]$WinServer,
+        [Parameter(Position=3)]
+        [pscredential]$WinCred,
+        [switch]$WinUseSSL,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
+
+    $cim = Connect-WinDns @PSBoundParameters
+    Write-Verbose "Connected to $WinServer"
+
+    $dnsParams = @{ ComputerName=$WinServer; CimSession=$cim }
+
+    Write-Debug "Attempting to find zone for $RecordName"
+    if (!($zoneName = Find-WinZone $RecordName $dnsParams)) {
+        throw "Unable to find zone for $RecordName"
+    }
+    $zone = Get-DnsServerZone $zoneName @dnsParams -EA Stop
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName.Replace(".$ZoneName",'')
+
+    $recs = @($zone | Get-DnsServerResourceRecord -Name $recShort -RRType Txt -EA SilentlyContinue)
+
+    if ($recs.Count -gt 0 -and $TxtValue -in $recs.RecordData.DescriptiveText) {
+        # remove the record that has the right value
+        $toDelete = $recs | Where-Object { $_.RecordData.DescriptiveText -eq $TxtValue }
+        Write-Verbose "Deleting $RecordName with value $TxtValue"
+        $zone | Remove-DnsServerResourceRecord -InputObject $toDelete -Force
+    } else {
+        # nothing to do
+        Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."
+    }
 
     <#
     .SYNOPSIS
@@ -58,13 +133,27 @@ function Remove-DnsTxtWindows {
     .PARAMETER TxtValue
         The value of the TXT record.
 
+    .PARAMETER WinServer
+        The hostname or IP address of the Windows DNS server.
+
+    .PARAMETER WinCred
+        Credentials with permissions to modify TXT records in the specified zone. This is optional if the current user has the proper permissions already.
+
+    .PARAMETER WinUseSSL
+        Forces the PowerShell remoting session to run over HTTPS. Requires the server have a valid certificate that is installed and trusted by the client or added to the client's TrustedHosts list. This is primarily used when connecting to a non-domain joined DNS server.
+
     .PARAMETER ExtraParams
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
 
     .EXAMPLE
-        Remove-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678'
+        Remove-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678' -WinServer 'dns1.example.com'
 
-        Removes a TXT record for the specified site with the specified value.
+        Removes a TXT record using the credentials of the calling process.
+
+    .EXAMPLE
+        Remove-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678' -WinServer 'dns1.example.com' -WinCred (Get-Credential) -WinUseSSL
+
+        Removes a TXT record using explicit credentials and connecting over HTTPS.
     #>
 }
 
@@ -92,3 +181,74 @@ function Save-DnsTxtWindows {
 ############################
 # Helper Functions
 ############################
+
+function Connect-WinDns {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$WinServer,
+        [Parameter(Position=1)]
+        [pscredential]$WinCred,
+        [switch]$WinUseSSL,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    # create a new CimSession if necessary
+    if (Get-CimSession -ComputerName $WinServer -EA SilentlyContinue) {
+        Write-Debug "Using existing CimSession for $WinServer"
+        return ((Get-CimSession -ComputerName $WinServer)[0])
+    } else {
+        Write-Debug "Connecting to $WinServer"
+        $cimParams = @{ ComputerName=$WinServer }
+        if ($WinCred) { $cimParams.Credential = $WinCred }
+        if ($WinUseSSL) { $cimParams.SessionOption = (New-CimSessionOption -UseSsl) }
+        return (New-CimSession @cimParams)
+    }
+
+}
+
+function Find-WinZone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position=1)]
+        [hashtable]$DnsParams
+    )
+
+    # setup a module variable to cache the record to zone mapping
+    # so it's quicker to find later
+    if (!$script:WinRecordZones) { $script:WinRecordZones = @{} }
+
+    # check for the record in the cache
+    if ($script:WinRecordZones.ContainsKey($RecordName)) {
+        return $script:WinRecordZones.$RecordName
+    }
+
+    # get the zone list
+    $zones = @(Get-DnsServerZone @DnsParams -EA Stop | Where-Object { !$_.IsAutoCreated -and $_.ZoneName -ne 'TrustAnchors' })
+
+    # Since Windows could be hosting both apex and sub-zones, we need to find the closest/deepest
+    # sub-zone that would hold the record rather than just adding it to the apex. So for something
+    # like _acme-challenge.site1.sub1.sub2.example.com, we'd look for zone matches in the following
+    # order:
+    # - site1.sub1.sub2.example.com
+    # - sub1.sub2.example.com
+    # - sub2.example.com
+    # - example.com
+
+    $pieces = $RecordName.Split('.')
+    for ($i=1; $i -lt ($pieces.Count-1); $i++) {
+        $zoneTest = "$( $pieces[$i..($pieces.Count-1)] -join '.' )"
+        Write-Debug "Checking $zoneTest"
+
+        if ($zoneTest -in $zones.ZoneName) {
+            $zoneName = ($zones | Where-Object { $_.ZoneName -eq $zoneTest }).ZoneName
+            $script:WinRecordZones.$RecordName = $zoneName
+            return $zoneName
+        }
+    }
+
+    return $null
+}

--- a/Posh-ACME/DnsPlugins/Windows.ps1
+++ b/Posh-ACME/DnsPlugins/Windows.ps1
@@ -1,0 +1,94 @@
+#Requires -Modules DnsServer
+
+function Add-DnsTxtWindows {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position=1)]
+        [string]$TxtValue,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    <#
+    .SYNOPSIS
+        Add a DNS TXT record to a Windows DNS server
+
+    .DESCRIPTION
+        This plugin requires the "DnsServer" PowerShell module to be installed. On Windows Server OSes, you can install it with "Install-WindowsFeature RSAT-DNS-Server". On Windows client OSes, you will need to download and install the RSAT tools for your OS.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER TxtValue
+        The value of the TXT record.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+
+    .EXAMPLE
+        Add-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678'
+
+        Adds a TXT record for the specified site with the specified value.
+    #>
+}
+
+function Remove-DnsTxtWindows {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position=1)]
+        [string]$TxtValue,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    <#
+    .SYNOPSIS
+        Remove a DNS TXT record from a Windows DNS server
+
+    .DESCRIPTION
+        This plugin requires the "DnsServer" PowerShell module to be installed. On Windows Server OSes, you can install it with "Install-WindowsFeature RSAT-DNS-Server". On Windows client OSes, you will need to download and install the RSAT tools for your OS.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER TxtValue
+        The value of the TXT record.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+
+    .EXAMPLE
+        Remove-DnsTxtWindows '_acme-challenge.site1.example.com' 'asdfqwer12345678'
+
+        Removes a TXT record for the specified site with the specified value.
+    #>
+}
+
+function Save-DnsTxtWindows {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    # Nothing to do. Windows doesn't require a save step
+
+    <#
+    .SYNOPSIS
+        Not required for Windows.
+
+    .DESCRIPTION
+        Windows does not require calling this function to commit changes to DNS records.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    #>
+}
+
+############################
+# Helper Functions
+############################


### PR DESCRIPTION
Adds a `Windows` plugin which addresses issue #2.

Relies on Microsoft `DnsServer` and `CimCmdlets` modules. Currently untested on anything earlier than Windows 10 and Server 2016. But should work on any OSes that support those modules.