### PR TITLE
Fix for multiple DNS zones in subscription

### DIFF
--- a/Posh-ACME/DnsPlugins/Azure.ps1
+++ b/Posh-ACME/DnsPlugins/Azure.ps1
@@ -277,7 +277,7 @@ function Get-AZZoneId {
     # - sub2.example.com
     # - example.com
 
-    Write-Verbose $zones.value.name
+    Write-Verbose "Found zones: $($zones.value.name -join ', ')"
 
     $pieces = $RecordName.Split('.')
     for ($i=1; $i -lt ($pieces.Count-1); $i++) {


### PR DESCRIPTION
Hi,
little bug found on using an azure subscription with several DNS zones:

Write-Verbose threw an error when using an Azure subscriptions with multiple DNS zones:

```
Get-AZZoneId : Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'Message'. Specified method is not supported.
At C:\Program Files\WindowsPowerShell\Modules\Posh-ACME\2.0\DnsPlugins\Azure.ps1:21 char:21
+     if (!($zoneID = Get-AZZoneId $RecordName $AZSubscriptionId)) {
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-AZZoneId], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgument,Get-AZZoneId
```

Best regards
Julian