### PR TITLE
Add -UseBasicParsing to all remote calls

### DIFF
--- a/Posh-ACME/DnsPlugins/AcmeDns.ps1
+++ b/Posh-ACME/DnsPlugins/AcmeDns.ps1
@@ -50,7 +50,8 @@ function Add-DnsTxtAcmeDns {
     # send the update
     try {
         Write-Verbose "Updating $($regVals[3]) with $TxtValue"
-        $response = Invoke-RestMethod "https://$ACMEServer/update" -Method Post -Headers $authHead -Body $updateBody
+        $response = Invoke-RestMethod "https://$ACMEServer/update" -Method Post `
+            -Headers $authHead -Body $updateBody @script:UseBasic
         Write-Debug ($response | ConvertTo-Json)
     } catch { throw }
 
@@ -191,7 +192,8 @@ function New-AcmeDnsRegistration {
     # do the registration
     try {
         Write-Verbose "Registering new subdomain on $ACMEServer"
-        $reg = Invoke-RestMethod "https://$ACMEServer/register" -Method POST -Body $regBody -ContentType 'application/json'
+        $reg = Invoke-RestMethod "https://$ACMEServer/register" -Method POST -Body $regBody `
+            -ContentType 'application/json' @script:UseBasic
         Write-Debug ($reg | ConvertTo-Json)
     } catch { throw }
 

--- a/Posh-ACME/DnsPlugins/Azure.ps1
+++ b/Posh-ACME/DnsPlugins/Azure.ps1
@@ -42,7 +42,8 @@ function Add-DnsTxtAzure {
     Write-Debug $recBody
     try {
         $response = Invoke-RestMethod "https://management.azure.com$($rec.id)?api-version=2018-03-01-preview" `
-                        -Method Put -Body $recBody -Headers $script:AZToken.AuthHeader -ContentType 'application/json'
+            -Method Put -Body $recBody -Headers $script:AZToken.AuthHeader `
+            -ContentType 'application/json' @script:UseBasic
         Write-Debug ($response | ConvertTo-Json -Depth 5)
     } catch { throw }
 
@@ -133,7 +134,7 @@ function Remove-DnsTxtAzure {
         Write-Verbose "Deleting $($rec.name). No values left."
         try {
             Invoke-RestMethod "https://management.azure.com$($rec.id)?api-version=2018-03-01-preview" `
-                    -Method Delete -Headers $script:AZToken.AuthHeader | Out-Null
+                -Method Delete -Headers $script:AZToken.AuthHeader  @script:UseBasic | Out-Null
             return
         } catch { throw }
     }
@@ -145,7 +146,8 @@ function Remove-DnsTxtAzure {
     Write-Debug $recBody
     try {
         $response = Invoke-RestMethod "https://management.azure.com$($rec.id)?api-version=2018-03-01-preview" `
-                        -Method Put -Body $recBody -Headers $script:AZToken.AuthHeader -ContentType 'application/json'
+            -Method Put -Body $recBody -Headers $script:AZToken.AuthHeader `
+            -ContentType 'application/json' @script:UseBasic
         Write-Debug ($response | ConvertTo-Json -Depth 5)
     } catch { throw }
 
@@ -232,7 +234,8 @@ function Connect-AZTenant {
 
     # login
     try {
-        $token = Invoke-RestMethod "https://login.microsoftonline.com/$($AZTenantId)/oauth2/token" -Method Post -Body $authBody
+        $token = Invoke-RestMethod "https://login.microsoftonline.com/$($AZTenantId)/oauth2/token" `
+            -Method Post -Body $authBody @script:UseBasic
     } catch { throw }
 
     # add an "Expires" [datetime] parameter converted from expires_on with a 5 min buffer
@@ -265,7 +268,7 @@ function Get-AZZoneId {
     # https://docs.microsoft.com/en-us/rest/api/dns/zones/list
     $url = "https://management.azure.com/subscriptions/$($AZSubscriptionId)/providers/Microsoft.Network/dnszones?api-version=2018-03-01-preview"
     try {
-        $zones = Invoke-RestMethod $url -Headers $script:AZToken.AuthHeader
+        $zones = Invoke-RestMethod $url -Headers $script:AZToken.AuthHeader @script:UseBasic
     } catch { throw }
 
     # Since Azure could be hosting both apex and sub-zones, we need to find the closest/deepest
@@ -312,7 +315,8 @@ function Get-AZTxtRecord {
     # query the specific record we're looking to modify
     Write-Verbose "Querying $RecordName"
     try {
-        $rec = Invoke-RestMethod "https://management.azure.com$($recID)?api-version=2018-03-01-preview" -Headers $script:AZToken.AuthHeader
+        $rec = Invoke-RestMethod "https://management.azure.com$($recID)?api-version=2018-03-01-preview" `
+            -Headers $script:AZToken.AuthHeader @script:UseBasic
     } catch {}
 
     if ($rec) {

--- a/Posh-ACME/DnsPlugins/DMEasy.ps1
+++ b/Posh-ACME/DnsPlugins/DMEasy.ps1
@@ -32,7 +32,8 @@ function Add-DnsTxtDMEasy {
     # query the existing record(s)
     try {
         $auth = Get-DMEAuthHeader $DMEKey $DMESecret
-        $response = Invoke-RestMethod "$($recRoot)?recordName=$recShort&type=TXT" -Headers $auth -ContentType 'application/json'
+        $response = Invoke-RestMethod "$($recRoot)?recordName=$recShort&type=TXT" `
+            -Headers $auth -ContentType 'application/json' @script:UseBasic
     } catch { throw }
 
     # check if our value is already in there
@@ -48,7 +49,8 @@ function Add-DnsTxtDMEasy {
         $auth = Get-DMEAuthHeader $DMEKey $DMESecret
         $bodyJson = @{name=$recShort;value="`"$TxtValue`"";type='TXT';ttl=10} | ConvertTo-Json -Compress
         Write-Verbose "Creating $RecordName with value $TxtValue"
-        Invoke-RestMethod $recRoot -Method Post -Body $bodyJson -Headers $auth -ContentType 'application/json' | Out-Null
+        Invoke-RestMethod $recRoot -Method Post -Body $bodyJson -Headers $auth `
+            -ContentType 'application/json' @script:UseBasic | Out-Null
     } catch { throw }
 
     <#
@@ -118,7 +120,8 @@ function Remove-DnsTxtDMEasy {
     # query the existing record(s)
     try {
         $auth = Get-DMEAuthHeader $DMEKey $DMESecret
-        $response = Invoke-RestMethod "$($recRoot)?recordName=$recShort&type=TXT" -Headers $auth -ContentType 'application/json'
+        $response = Invoke-RestMethod "$($recRoot)?recordName=$recShort&type=TXT" `
+            -Headers $auth -ContentType 'application/json' @script:UseBasic
     } catch { throw }
 
     # check for the value to delete
@@ -135,7 +138,8 @@ function Remove-DnsTxtDMEasy {
         try {
             $auth = $auth = Get-DMEAuthHeader $DMEKey $DMESecret
             Write-Verbose "Deleting record $RecordName with value $TxtValue."
-            Invoke-RestMethod "$recRoot/$recID" -Method Delete -Headers $auth -ContentType 'application/json' | Out-Null
+            Invoke-RestMethod "$recRoot/$recID" -Method Delete -Headers $auth `
+                -ContentType 'application/json' @script:UseBasic | Out-Null
         } catch { throw }
     }
 
@@ -258,7 +262,7 @@ function Find-DMEZone {
     # customers find differently, feel free to submit an issue.
     try {
         $auth = Get-DMEAuthHeader $DMEKey $DMESecret
-        $response = Invoke-RestMethod $ApiBase -Headers $auth -ContentType 'application/json'
+        $response = Invoke-RestMethod $ApiBase -Headers $auth -ContentType 'application/json' @script:UseBasic
         $zones = $response.data
     } catch { throw }
 

--- a/Posh-ACME/DnsPlugins/DOcean.ps1
+++ b/Posh-ACME/DnsPlugins/DOcean.ps1
@@ -26,7 +26,7 @@ function Add-DnsTxtDOcean {
 
     # query the current text record
     try {
-        $rec = (Invoke-RestMethod $recRoot @restParams).domain_records |
+        $rec = (Invoke-RestMethod $recRoot @restParams @script:UseBasic).domain_records |
                 Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort -and $_.data -eq $TxtValue }
     } catch { throw }
 
@@ -39,7 +39,7 @@ function Add-DnsTxtDOcean {
             ttl  = 10;
         } | ConvertTo-Json
         Write-Verbose "Adding a TXT record for $RecordName with value $TxtValue"
-        Invoke-RestMethod $recRoot -Method Post @restParams -Body $recBody -EA Stop | Out-Null
+        Invoke-RestMethod $recRoot -Method Post @restParams -Body $recBody -EA Stop @script:UseBasic | Out-Null
     } else {
         Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
     }
@@ -98,14 +98,14 @@ function Remove-DnsTxtDOcean {
 
     # query the current text record
     try {
-        $rec = (Invoke-RestMethod $recRoot @restParams).domain_records |
+        $rec = (Invoke-RestMethod $recRoot @restParams @script:UseBasic).domain_records |
                 Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort -and $_.data -eq $TxtValue }
     } catch { throw }
 
     if ($rec) {
         # delete it
         Write-Verbose "Deleting $RecordName with value $TxtValue"
-        Invoke-RestMethod "$recRoot/$($rec.id)" -Method Delete @restParams -EA Stop | Out-Null
+        Invoke-RestMethod "$recRoot/$($rec.id)" -Method Delete @restParams -EA Stop @script:UseBasic | Out-Null
     } else {
         # nothing to do
         Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."
@@ -181,7 +181,7 @@ function Find-DOZone {
     }
 
     try {
-        $zones = (Invoke-RestMethod "$ApiRoot" @RestParams).domains
+        $zones = (Invoke-RestMethod "$ApiRoot" @RestParams @script:UseBasic).domains
     } catch { throw }
 
     # Since Digital Ocean could be hosting both apex and sub-zones, we need to find the closest/deepest

--- a/Posh-ACME/DnsPlugins/GCloud.ps1
+++ b/Posh-ACME/DnsPlugins/GCloud.ps1
@@ -27,7 +27,8 @@ function Add-DnsTxtGCloud {
 
     # query the current txt record set
     try {
-        $response = Invoke-RestMethod "$recRoot/rrsets?type=TXT&name=$RecordName." -Headers $script:GCToken.AuthHeader
+        $response = Invoke-RestMethod "$recRoot/rrsets?type=TXT&name=$RecordName." `
+            -Headers $script:GCToken.AuthHeader @script:UseBasic
         Write-Debug ($response | ConvertTo-Json -Depth 5)
     } catch { throw }
     $rrsets = $response.rrsets
@@ -62,7 +63,10 @@ function Add-DnsTxtGCloud {
     Write-Verbose "Sending update for $RecordName"
     Write-Debug ($changeBody | ConvertTo-Json -Depth 5)
     try {
-        $response = Invoke-RestMethod "$recRoot/changes" -Method Post -Body ($changeBody | ConvertTo-Json -Depth 5) -Headers $script:GCToken.AuthHeader -ContentType 'application/json'
+        $response = Invoke-RestMethod "$recRoot/changes" -Method Post `
+            -Body ($changeBody | ConvertTo-Json -Depth 5) `
+            -Headers $script:GCToken.AuthHeader `
+            -ContentType 'application/json' @script:UseBasic
         Write-Debug ($response | ConvertTo-Json -Depth 5)
     } catch { throw }
 
@@ -124,7 +128,8 @@ function Remove-DnsTxtGCloud {
 
     # query the current txt record set
     try {
-        $response = Invoke-RestMethod "$recRoot/rrsets?type=TXT&name=$RecordName." -Headers $script:GCToken.AuthHeader
+        $response = Invoke-RestMethod "$recRoot/rrsets?type=TXT&name=$RecordName." `
+            -Headers $script:GCToken.AuthHeader @script:UseBasic
         Write-Debug ($response | ConvertTo-Json -Depth 5)
     } catch { throw }
     $rrsets = $response.rrsets
@@ -154,7 +159,10 @@ function Remove-DnsTxtGCloud {
     Write-Verbose "Sending update for $RecordName"
     Write-Debug ($changeBody | ConvertTo-Json -Depth 5)
     try {
-        $response = Invoke-RestMethod "$recRoot/changes" -Method Post -Body ($changeBody | ConvertTo-Json -Depth 5) -Headers $script:GCToken.AuthHeader -ContentType 'application/json'
+        $response = Invoke-RestMethod "$recRoot/changes" -Method Post `
+            -Body ($changeBody | ConvertTo-Json -Depth 5) `
+            -Headers $script:GCToken.AuthHeader `
+            -ContentType 'application/json' @script:UseBasic
         Write-Debug ($response | ConvertTo-Json -Depth 5)
     } catch { throw }
 
@@ -273,7 +281,7 @@ function Connect-GCloudDns {
     # attempt to sign in
     try {
         Write-Debug "Sending OAuth2 login"
-        $response = Invoke-RestMethod $GCKeyObj.token_uri -Method Post -Body $authBody
+        $response = Invoke-RestMethod $GCKeyObj.token_uri -Method Post -Body $authBody @script:UseBasic
         Write-Debug ($response | ConvertTo-Json)
     } catch { throw }
 
@@ -307,7 +315,8 @@ function Find-GCZone {
 
     # get the list of available zones
     try {
-        $zones = (Invoke-RestMethod "$projRoot/managedZones" -Headers $script:GCToken.AuthHeader).managedZones
+        $zones = (Invoke-RestMethod "$projRoot/managedZones" `
+            -Headers $script:GCToken.AuthHeader).managedZones @script:UseBasic
     } catch { throw }
 
     # Since Google could be hosting both apex and sub-zones, we need to find the closest/deepest

--- a/Posh-ACME/DnsPlugins/Infoblox.ps1
+++ b/Posh-ACME/DnsPlugins/Infoblox.ps1
@@ -22,7 +22,7 @@ function Add-DnsTxtInfoblox {
         if ($IBIgnoreCert) { [CertValidation]::Ignore() }
 
         # send the POST
-        $response = Invoke-RestMethod -Uri $apiUrl -Method Post -Credential $IBCred
+        $response = Invoke-RestMethod -Uri $apiUrl -Method Post -Credential $IBCred @script:UseBasic
 
         Write-Verbose "TXT Record created: $response"
 
@@ -111,13 +111,13 @@ function Remove-DnsTxtInfoblox {
 
         # query the _ref for the txt record object we want to delete
         $checkUrl = "https://$IBServer/wapi/v1.0/record:txt?name=$RecordName&text=$TxtValue&view=$IBView"
-        $response = Invoke-RestMethod -Uri $checkUrl -Method Get -Credential $IBCred
+        $response = Invoke-RestMethod -Uri $checkUrl -Method Get -Credential $IBCred @script:UseBasic
 
         if ($response -and $response.'_ref') {
 
             # delete the record
             $delUrl = "https://$IBServer/wapi/v1.0/$($response.'_ref')"
-            $response = Invoke-RestMethod -Uri $delUrl -Method Delete -Credential $IBCred
+            $response = Invoke-RestMethod -Uri $delUrl -Method Delete -Credential $IBCred @script:UseBasic
             Write-Verbose "TXT Record deleted: $response"
         }
 

--- a/Posh-ACME/DnsPlugins/README.md
+++ b/Posh-ACME/DnsPlugins/README.md
@@ -75,6 +75,13 @@ When testing your module, use `-Verbose` to see your verbose messages. And run `
 
 Do not output any objects to the pipeline from your plugin. This will interfere with scripts and workflows that use the normal output of public functions. You can use `Out-Null` on functions that may generate pipeline output but you may not be using the output from.
 
+### -UseBasicParsing
+
+Any time you call `Invoke-WebRequest` or `Invoke-RestMethod`, you should always add `@script:UseBasic` to the end.
+
+By default in PowerShell 5.1, those two functions use Internet Explorer's DOM parser to process the response body which can cause errors in cases where IE is not installed or hasn't gone through its first-run sequence yet. Both functions have a `-UseBasicParsing` that switches the parser to a PowerShell native parser and is the new default functionality in PowerShell Core 6. The parameter is also deprecated because they don't plan on bringing back IE DOM parsing in future PowerShell versions. So the module creates a variable when it's first loaded that checks whether `-UseBasicParsing` is still available or not and adds it to the `$script:UseBasic` hashtable. That way, you can just splat it on all your calls to those two functions which
+will future proof your plugin.
+
 ## Testing Plugins
 
 Plugins can be tested using `Publish-DnsChallenge`, `Unpublish-DnsChallenge`, and `Save-DnsChallenge`. They call the Add, Remove, and Save functions respectively. Use `Get-Help` on those functions for more information on how to use them.

--- a/Posh-ACME/Posh-ACME.psm1
+++ b/Posh-ACME/Posh-ACME.psm1
@@ -25,7 +25,22 @@ $script:WellKnownDirs = @{
 $script:HEADER_NONCE = 'Replay-Nonce'
 $script:USER_AGENT = "Posh-ACME/2.0.1 PowerShell/$($PSVersionTable.PSVersion)"
 $script:COMMON_HEADERS = @{'Accept-Language'='en-us,en;q=0.5'}
-$script:CONTENT_TYPE = 'application/jose+json'
+
+# Invoke-WebRequest and Invoke-RestMethod on PowerShell 5.1 both use
+# IE's DOM parser by default which gives you some nice things that we
+# don't use like html/form parsing. The problem is that it can generate
+# errors if IE is not installed or hasn't gone through the first-run
+# sequence in a new profile. Fortunately, there's a -UseBasicParsing switch
+# on both functions that uses a PowerShell native parser instead and avoids
+# those problems. In PowerShell Core 6, the parameter has been deprecated
+# because there is no IE DOM parser to use and all requests use the native
+# parser by default. In order to future proof ourselves for the switch's
+# eventual removal, we'll set it only if it actually exists in this
+# environment.
+$script:UseBasic = @{}
+if ('UseBasicParsing' -in (Get-Command Invoke-WebRequest).Parameters.Keys) {
+    $script:UseBasic.UseBasicParsing = $true
+}
 
 # setup the DnsPlugin argument completer
 # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/register-argumentcompleter?view=powershell-5.1

--- a/Posh-ACME/Private/Export-PACertFiles.ps1
+++ b/Posh-ACME/Private/Export-PACertFiles.ps1
@@ -19,7 +19,7 @@ function Export-PACertFiles {
 
     # download the cert+chain which is what ACMEv2 delivers by default
     # https://tools.ietf.org/html/draft-ietf-acme-acme-12#section-7.4.2
-    Invoke-WebRequest $CertUrl -OutFile $fullchainFile
+    Invoke-WebRequest $CertUrl -OutFile $fullchainFile @script:UseBasic
 
     # split it into individual PEMs
     $pems = Split-PemChain $fullchainFile

--- a/Posh-ACME/Private/Get-Nonce.ps1
+++ b/Posh-ACME/Private/Get-Nonce.ps1
@@ -23,7 +23,9 @@ function Get-Nonce {
         # make the request
         Write-Debug "Requesting nonce from $NewNonceUrl"
         try {
-            $response = Invoke-WebRequest $NewNonceUrl -Method Head -UserAgent $script:USER_AGENT -Headers $script:COMMON_HEADERS -EA Stop -Verbose:$false
+            $response = Invoke-WebRequest $NewNonceUrl -Method Head `
+                -UserAgent $script:USER_AGENT -Headers $script:COMMON_HEADERS `
+                -EA Stop -Verbose:$false @script:UseBasic
         } catch { throw }
 
         # return the value from the response

--- a/Posh-ACME/Private/Invoke-ACME.ps1
+++ b/Posh-ACME/Private/Invoke-ACME.ps1
@@ -29,18 +29,13 @@ function Invoke-ACME {
     # like badNonce which requires modifying the Header and re-signing a new JWS.
     $Jws = New-Jws $Key $Header $PayloadJson
 
-    $CommonParams = @{
-        Method = 'Post';
-        ContentType = $script:CONTENT_TYPE;
-        UserAgent = $script:USER_AGENT;
-        Headers = $script:COMMON_HEADERS;
-    }
-
     # since HTTP error codes make Invoke-WebRequest throw an exception,
     # we need to wrap it in a try/catch. But we can still get the response
     # object via the exception.
     try {
-        $response = Invoke-WebRequest -Uri $Uri -Body $Jws @CommonParams -ErrorAction Stop
+        $response = Invoke-WebRequest -Uri $Uri -Body $Jws -Method Post `
+            -ContentType 'application/jose+json' -UserAgent $script:USER_AGENT `
+            -Headers $script:COMMON_HEADERS -EA Stop @script:UseBasic
 
         # update the next nonce if it was sent
         if ($response.Headers.ContainsKey($script:HEADER_NONCE)) {

--- a/Posh-ACME/Private/Update-PAOrder.ps1
+++ b/Posh-ACME/Private/Update-PAOrder.ps1
@@ -39,7 +39,7 @@ function Update-PAOrder {
 
             # we can request the order info via an anonymous GET request
             try {
-                $response = Invoke-WebRequest $order.location -Verbose:$false -ErrorAction Stop
+                $response = Invoke-WebRequest $order.location -EA Stop -Verbose:$false @script:UseBasic
             } catch { throw }
             Write-Debug "Response: $($response.Content)"
 

--- a/Posh-ACME/Private/Update-PAServer.ps1
+++ b/Posh-ACME/Private/Update-PAServer.ps1
@@ -44,7 +44,7 @@ function Update-PAServer {
             # make the request
             Write-Debug "Updating directory info from $DirectoryUrl"
             try {
-                $response = Invoke-WebRequest $DirectoryUrl -Verbose:$false -ErrorAction Stop
+                $response = Invoke-WebRequest $DirectoryUrl -EA Stop -Verbose:$false @script:UseBasic
             } catch { throw }
             $dirObj = $response.Content | ConvertFrom-Json
 

--- a/Posh-ACME/Public/Get-PAAuthorizations.ps1
+++ b/Posh-ACME/Public/Get-PAAuthorizations.ps1
@@ -21,7 +21,7 @@ function Get-PAAuthorizations {
         foreach ($AuthUrl in $AuthUrls) {
 
             # request the object and inject the type name
-            $auth = Invoke-RestMethod $AuthUrl -Verbose:$false
+            $auth = Invoke-RestMethod $AuthUrl -Verbose:$false @script:UseBasic
             $auth.PSObject.TypeNames.Insert(0,'PoshACME.PAAuthorization')
             Write-Debug "Response: $($auth | ConvertTo-Json)"
 


### PR DESCRIPTION
This change addresses issue #27 which requests the addition of the `-UseBasicParsing` flag to all instances of `Invoke-WebRequest` and `Invoke-RestMethod`.

Because `-UseBasicParsing` is a deprecated switch as of PowerShell Core 6, it is implemented as a module-wide variable called `$script:UseBasic` which is a hashtable that contains `UseBasicParsing=$true` but only if the switch still exists. Otherwise, it's just an empty hashtable.

All current calls to the two functions have `@script:UseBasic` added to them and all future calls should as well. We'll have to be diligent when reviewing new plugin requests.