### PR TITLE
fix #60 re: order params not being saved when new order skips pending…

### DIFF
--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -118,32 +118,42 @@ function New-PACertificate {
         $order | Set-PAOrder
     }
 
+    # add validation parameters to the order object using explicit params
+    # backed up by previous order params
+    if ('DnsPlugin' -in $PSBoundParameters.Keys) {
+        $order.DnsPlugin = $DnsPlugin
+    } elseif ($oldOrder) {
+        $order.DnsPlugin = $oldOrder.DnsPlugin
+    }
+    if ('DnsAlias' -in $PSBoundParameters.Keys) {
+        $order.DnsAlias = $DnsAlias
+    } elseif ($oldOrder) {
+        $order.DnsAlias = $oldOrder.DnsAlias
+    }
+    $order.DnsSleep = $DnsSleep
+    if ($oldOrder -and 'DnsSleep' -notin $PSBoundParameters.Keys) {
+        $order.DnsSleep = $oldOrder.DnsSleep
+    }
+    $order.ValidationTimeout = $ValidationTimeout
+    if ($oldOrder -and 'ValidationTimeout' -notin $PSBoundParameters.Keys) {
+        $order.ValidationTimeout = $oldOrder.ValidationTimeout
+    }
+    Write-Debug "Saving validation params to order"
+    $order | Update-PAOrder -SaveOnly
+
     # deal with "pending" orders that may have authorization challenges to prove
     if ($order.status -eq 'pending') {
 
         # create a hashtable of validation parameters to splat that uses
         # explicit params backed up by previous order params
-        $chalParams = @{}
-        if ('DnsPlugin' -in $PSBoundParameters.Keys) {
-            $chalParams.DnsPlugin = $DnsPlugin
-        } elseif ($oldOrder) {
-            $chalParams.DnsPlugin = $oldOrder.DnsPlugin
+        $chalParams = @{
+            DnsPlugin = $order.DnsPlugin
+            DnsAlias = $order.DnsAlias
+            DnsSleep = $order.DnsSleep
+            ValidationTimeout = $order.ValidationTimeout
         }
         if ('PluginArgs' -in $PSBoundParameters.Keys) {
             $chalParams.PluginArgs = $PluginArgs
-        }
-        if ('DnsAlias' -in $PSBoundParameters.Keys) {
-            $chalParams.DnsAlias = $DnsAlias
-        } elseif ($oldOrder) {
-            $chalParams.DnsAlias = $oldOrder.DnsAlias
-        }
-        $chalParams.DnsSleep = $DnsSleep
-        if ($oldOrder -and 'DnsSleep' -notin $PSBoundParameters.Keys) {
-            $chalParams.DnsSleep = $oldOrder.DnsSleep
-        }
-        $chalParams.ValidationTimeout = $ValidationTimeout
-        if ($oldOrder -and 'ValidationTimeout' -notin $PSBoundParameters.Keys) {
-            $chalParams.ValidationTimeout = $oldOrder.ValidationTimeout
         }
 
         Submit-ChallengeValidation @chalParams

--- a/Posh-ACME/Public/Submit-ChallengeValidation.ps1
+++ b/Posh-ACME/Public/Submit-ChallengeValidation.ps1
@@ -99,13 +99,6 @@ function Submit-ChallengeValidation {
     }
     Write-Debug "DnsAlias: $($DnsAlias -join ',')"
 
-    # save order specific parameters to order object so we can renew later
-    $order.DnsPlugin = $DnsPlugin
-    $order.DnsAlias = $DnsAlias
-    $order.DnsSleep = $DnsSleep
-    $order.ValidationTimeout = $ValidationTimeout
-    $order | Update-PAOrder -SaveOnly
-
     # merge passed in plugin args with saved args (which also saves the merged copy)
     $PluginArgs = Merge-PluginArgs $PluginArgs $Account
 


### PR DESCRIPTION
This is a quick fix for the bug introduced by Let's Encrypt now supporting the "ready" order status which happens when an order has all necessarily challenges validated. Previously, the order would remain as "pending" status until it was finalized. The logic in `New-PACertificate` only saved some of the order params (most notably `DnsPlugin` as part of a call to `Submit-ChallengeValidation`. But `Submit-ChallengeValidation` was only called if the order status was "pending". Since new orders with previously validated challenges now skip the pending state, `Submit-ChallengeValidation` was never called and those parameters would be empty on the cached order object. So renewals would ultimately fail.