### PR TITLE
Fix DNS clean-up when TXT records are not created for all domains

### DIFF
--- a/Posh-ACME/Public/Submit-ChallengeValidation.ps1
+++ b/Posh-ACME/Public/Submit-ChallengeValidation.ps1
@@ -159,12 +159,14 @@ function Submit-ChallengeValidation {
     } finally {
         # always cleanup the TXT records if they were added
         for ($i=0; $i -lt $toValidate.Count; $i++) {
-            if ([string]::IsNullOrWhiteSpace($DnsAlias[$i])) {
+            $index = $toValidate[$i]
+
+            if ([string]::IsNullOrWhiteSpace($DnsAlias[$index])) {
                 # unpublish normally
-                Unpublish-DnsChallenge $allAuths[$i].DNSId $Account $allAuths[$i].DNS01Token $DnsPlugin[$i] $PluginArgs
+                Unpublish-DnsChallenge $allAuths[$index].DNSId $Account $allAuths[$index].DNS01Token $DnsPlugin[$index] $PluginArgs
             } else {
                 # unpublish from alias
-                Unpublish-DnsChallenge $DnsAlias[$i] $Account $allAuths[$i].DNS01Token $DnsPlugin[$i] $PluginArgs -NoPrefix
+                Unpublish-DnsChallenge $DnsAlias[$index] $Account $allAuths[$index].DNS01Token $DnsPlugin[$index] $PluginArgs -NoPrefix
             }
         }
         $DnsPlugin[$toValidate] | Select-Object -Unique | ForEach-Object {


### PR DESCRIPTION
`$toValidate` is an array of domain indexes. The [DNS clean-up code](https://github.com/rmbolger/Posh-ACME/blob/655b15e97f8878f5b236477553bf356653e6796b/Posh-ACME/Public/Submit-ChallengeValidation.ps1#L160) is currently iterating over `$toValidate`, but using the loop variable to identify domains instead of looking up the domain index in `$toValidate`.

If a certificate was requested for two domains, but the first was already validated, a DNS record would only have been created for the second domain. The clean-up code would then try and delete a non-existent DNS record for the first domain instead of the record that was created for the second domain.

This pull request changes the DNS clean-up code to use the index from `$toValidate` to access the `$allAuths`, `$DnsAlias` and `$DnsPlugin` arrays.