### PR TITLE
Remove no longer needed try catches around calls to Get-Order

### DIFF
--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -66,8 +66,7 @@ function New-PACertificate {
     # - is pending, but expired
     # - has different KeyLength
     # - has different SANs
-    $order = $null
-    try { $order = Get-PAOrder $Domain[0] -Refresh } catch {}
+    $order = Get-PAOrder $Domain[0] -Refresh
     $SANs = @($Domain | Where-Object { $_ -ne $Domain[0] }) | Sort-Object
     if ($Force -or !$order -or
         $order.status -eq 'invalid' -or

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -21,9 +21,7 @@ function New-PAOrder {
         throw "No ACME account configured. Run Set-PAAccount or New-PAAccount first."
     }
 
-    # null the local instance of $order so it's not confused with the script-scoped version
-    $order = $null
-    try { $order = Get-PAOrder $Domain[0] -Refresh } catch {}
+    $order = Get-PAOrder $Domain[0] -Refresh
 
     # separate the SANs
     $SANs = @($Domain | Where-Object { $_ -ne $Domain[0] }) | Sort-Object


### PR DESCRIPTION
Commit d505fae771b9eba0507154ccfdd2aa27ab7491ac changed `Get-PAOrder` so that it returns `$null` instead of throwing an exception.

This pull request removes the try catch around the call to `Get-PAOrder` in [`New-PAOrder`](https://github.com/rmbolger/Posh-ACME/blob/655b15e97f8878f5b236477553bf356653e6796b/Posh-ACME/Public/New-PAOrder.ps1#L26) and [`New-PACertificate`](https://github.com/rmbolger/Posh-ACME/blob/655b15e97f8878f5b236477553bf356653e6796b/Posh-ACME/Public/New-PACertificate.ps1#L70), which I think is now unnecessary.

With this change, errors on refreshing the order (such as failures connecting to the ACME server) will now be surfaced instead of being silently caught and causing a new order or certificate to be created.