### PR TITLE
URL-encode the Azure client id and secret

### DIFF
--- a/Posh-ACME/DnsPlugins/Azure.ps1
+++ b/Posh-ACME/DnsPlugins/Azure.ps1
@@ -324,7 +324,10 @@ function Connect-AZTenant {
             # login
             try {
                 Write-Debug "Authenticating with explicit credentials"
-                $authBody = "grant_type=client_credentials&client_id=$($AZAppCred.Username)&client_secret=$($AZAppCred.GetNetworkCredential().Password)&resource=$([uri]::EscapeDataString('https://management.core.windows.net/'))"
+                $clientId = [uri]::EscapeDataString($AZAppCred.Username)
+                $clientSecret = [uri]::EscapeDataString($AZAppCred.GetNetworkCredential().Password)
+                $resource = [uri]::EscapeDataString('https://management.core.windows.net/')
+                $authBody = "grant_type=client_credentials&client_id=$clientId&client_secret=$clientSecret&resource=$resource"
                 $token = Invoke-RestMethod "https://login.microsoftonline.com/$($AZTenantId)/oauth2/token" `
                     -Method Post -Body $authBody @script:UseBasic
             } catch { throw }

--- a/Tests/Azure.Tests.ps1
+++ b/Tests/Azure.Tests.ps1
@@ -29,13 +29,15 @@ Describe "Connect-AZTenant" {
     Context "Credential param set" {
 
         $fakeTenant = '00000000-0000-0000-0000-000000000000'
-        $fakePass = "fakepass" | ConvertTo-SecureString -AsPlainText -Force
-        $fakeCred = New-Object System.Management.Automation.PSCredential('fakeuser', $fakePass)
+        $fakePass = "fake+p&ss" | ConvertTo-SecureString -AsPlainText -Force
+        $fakeCred = New-Object System.Management.Automation.PSCredential('fake user', $fakePass)
 
         It "calls Invoke-RestMethod if no existing token" {
             $script:AZToken = $null
             Connect-AZTenant $fakeTenant $fakeCred
-            Assert-MockCalled -CommandName Invoke-RestMethod -Times 1 -Exactly -Scope It
+            Assert-MockCalled -CommandName Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+                $Body -match "[&?]client_id=fake%20user(&|$)" -and $Body -match "[&?]client_secret=fake%2[Bb]p%26ss(&|$)"
+            }
             Assert-MockCalled -CommandName ConvertFrom-AccessToken -Times 0 -Exactly -Scope It
         }
         It "calls Invoke-RestMethod if token expired" {


### PR DESCRIPTION
The content type of the body of the `oauth2/token` request made in the Azure DNS plugin is `application/x-www-form-urlencoded`. The `client_id` and `client_secret` parameters must therefore be URL-encoded to allow characters such as '&' to be used in values.

This pull request adds the necessary url-encoding.