### PR TITLE
Implement POST-as-GET support

### DIFF
--- a/Posh-ACME/Private/Export-PACertFiles.ps1
+++ b/Posh-ACME/Private/Export-PACertFiles.ps1
@@ -1,25 +1,42 @@
 function Export-PACertFiles {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,Position=0)]
-        [string]$CertUrl,
-        [Parameter(Mandatory,Position=1)]
-        [string]$OutputFolder,
-        [string]$FriendlyName='',
-        [string]$PfxPass=''
+        [Parameter(Position=0)]
+        [PSTypeName('PoshACME.PAOrder')]$Order
     )
 
+    # Make sure we have an account configured
+    if (!($acct = Get-PAAccount)) {
+        throw "No ACME account configured. Run Set-PAAccount or New-PAAccount first."
+    }
+
+    # Make sure we have an order
+    if (-not $Order -and !($Order = Get-PAOrder)) {
+        throw "No ACME order specified and no current order selected. Run Set-PAOrder or specify an existing order object."
+    }
+    $orderFolder = Join-Path $script:AcctFolder $Order.MainDomain.Replace('*','!')
+
     # build output paths
-    $certFile      = Join-Path $OutputFolder 'cert.cer'
-    $keyFile       = Join-Path $OutputFolder 'cert.key'
-    $chainFile     = Join-Path $OutputFolder 'chain.cer'
-    $fullchainFile = Join-Path $OutputFolder 'fullchain.cer'
-    $pfxFile       = Join-Path $OutputFolder 'cert.pfx'
-    $pfxFullFile   = Join-Path $OutputFolder 'fullchain.pfx'
+    $certFile      = Join-Path $orderFolder 'cert.cer'
+    $keyFile       = Join-Path $orderFolder 'cert.key'
+    $chainFile     = Join-Path $orderFolder 'chain.cer'
+    $fullchainFile = Join-Path $orderFolder 'fullchain.cer'
+    $pfxFile       = Join-Path $orderFolder 'cert.pfx'
+    $pfxFullFile   = Join-Path $orderFolder 'fullchain.pfx'
+
+    # build the header for the Post-As-Get request
+    $header = @{
+        alg   = $acct.alg;
+        kid   = $acct.location;
+        nonce = $script:Dir.nonce;
+        url   = $order.certificate;
+    }
 
     # download the cert+chain which is what ACMEv2 delivers by default
     # https://tools.ietf.org/html/draft-ietf-acme-acme-12#section-7.4.2
-    Invoke-WebRequest $CertUrl -OutFile $fullchainFile @script:UseBasic
+    try {
+        Invoke-ACME $header ([String]::Empty) $acct -OutFile $fullchainFile -EA Stop
+    } catch { throw }
 
     # split it into individual PEMs
     $pems = Split-PemChain $fullchainFile

--- a/Posh-ACME/Private/Invoke-ACME.ps1
+++ b/Posh-ACME/Private/Invoke-ACME.ps1
@@ -11,7 +11,8 @@ function Invoke-ACME {
         [Parameter(ParameterSetName='RawKey',Mandatory,Position=2)]
         [ValidateScript({Test-ValidKey $_ -ThrowOnFail})]
         [Security.Cryptography.AsymmetricAlgorithm]$Key,
-        [switch]$NoRetry
+        [switch]$NoRetry,
+        [string]$OutFile
     )
 
     # make sure we have a server configured
@@ -45,12 +46,23 @@ function Invoke-ACME {
     # object via the exception.
 
     try {
-        $response = Invoke-WebRequest -Uri $Header.url -Body $Jws -Method Post `
-            -ContentType 'application/jose+json' -UserAgent $script:USER_AGENT `
-            -Headers $script:COMMON_HEADERS -EA Stop @script:UseBasic
+        $iwrSplat = @{
+            Uri = $Header.url
+            Body = $Jws
+            Method = 'Post'
+            ContentType = 'application/jose+json'
+            UserAgent = $script:USER_AGENT
+            Headers = $script:COMMON_HEADERS
+            ErrorAction = 'Stop'
+        }
+        if (-not [String]::IsNullOrWhiteSpace($OutFile)) {
+            $iwrSplat.OutFile = $OutFile
+        }
+
+        $response = Invoke-WebRequest @iwrSplat @script:UseBasic
 
         # update the next nonce if it was sent
-        if ($response.Headers.ContainsKey($script:HEADER_NONCE)) {
+        if ($response -and $response.Headers.ContainsKey($script:HEADER_NONCE)) {
             $script:Dir.nonce = $response.Headers[$script:HEADER_NONCE] | Select-Object -First 1
             Write-Debug "Updating nonce: $($script:Dir.nonce)"
         }
@@ -161,6 +173,9 @@ function Invoke-ACME {
 
     .PARAMETER NoRetry
         If specified, don't retry on bad nonce errors. Occasionally, the nonce provided in an ACME message will be rejected. By default, this function requests a new nonce once and tries to send the message again before giving up.
+
+    .PARAMETER OutFile
+        Specifies the output file for which this function saves the response body. Enter a path and file name. If you omit the path, the default is the current location.
 
     .EXAMPLE
         $acct = Get-PAAccount

--- a/Posh-ACME/Private/Invoke-ACME.ps1
+++ b/Posh-ACME/Private/Invoke-ACME.ps1
@@ -4,6 +4,7 @@ function Invoke-ACME {
         [Parameter(Mandatory,Position=0)]
         [hashtable]$Header,
         [Parameter(Mandatory,Position=1)]
+        [AllowEmptyString()]
         [string]$PayloadJson,
         [Parameter(ParameterSetName='Account',Mandatory,Position=2)]
         [PSTypeName('PoshACME.PAAccount')]$Account,

--- a/Posh-ACME/Private/New-Jws.ps1
+++ b/Posh-ACME/Private/New-Jws.ps1
@@ -7,6 +7,7 @@ function New-Jws {
         [Parameter(Mandatory)]
         [hashtable]$Header,
         [Parameter(Mandatory)]
+        [AllowEmptyString()]
         [string]$PayloadJson,
         [switch]$Compact,
         [switch]$NoHeaderValidation

--- a/Posh-ACME/Private/Update-PAAccount.ps1
+++ b/Posh-ACME/Private/Update-PAAccount.ps1
@@ -51,9 +51,7 @@ function Update-PAAccount {
 
         # send the request
         try {
-            $response = Invoke-ACME $header '{}' $acct -EA Stop
-            # POST-AS-GET support pending https://github.com/letsencrypt/pebble/pull/171
-            #$response = Invoke-ACME $header ([String]::Empty) $acct -EA Stop
+            $response = Invoke-ACME $header ([String]::Empty) $acct -EA Stop
         } catch { throw }
         Write-Debug "Response: $($response.Content)"
 

--- a/Posh-ACME/Private/Update-PAAccount.ps1
+++ b/Posh-ACME/Private/Update-PAAccount.ps1
@@ -49,12 +49,11 @@ function Update-PAAccount {
             url   = $acct.location;
         }
 
-        # empty payload to get the current details
-        $payloadJson = '{}'
-
         # send the request
         try {
-            $response = Invoke-ACME $header $payloadJson $acct -EA Stop
+            $response = Invoke-ACME $header '{}' $acct -EA Stop
+            # POST-AS-GET support pending https://github.com/letsencrypt/pebble/pull/171
+            #$response = Invoke-ACME $header ([String]::Empty) $acct -EA Stop
         } catch { throw }
         Write-Debug "Response: $($response.Content)"
 

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -207,13 +207,7 @@ function New-PACertificate {
         }
 
         # Download the cert chain, split it up, and generate a PFX files
-        $exportParams = @{
-            CertUrl = $order.certificate;
-            OutputFolder = $script:OrderFolder;
-            FriendlyName = $FriendlyName;
-            PfxPass = $PfxPass;
-        }
-        Export-PACertFiles @exportParams
+        Export-PACertFiles $order
 
         # check the certificate expiration date so we can update the CertExpires
         # and RenewAfter fields


### PR DESCRIPTION
This change implements POST-as-GET support as described in [Section 6.3 of ACME draft-16](https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-6.3) and the following community forum posts:
https://community.letsencrypt.org/t/acme-v2-scheduled-deprecation-of-unauthenticated-resource-gets/74380
https://community.letsencrypt.org/t/any-update-on-gets-posts-conversation/73139

Optional POST-as-GET support was added to the Staging and Production Let's Encrypt endpoints on October 25, 2018. It is currently scheduled to become required on November 1, 2019.