### PR TITLE
fix for Windows plugin add dnsParams to DnsServer commands

### DIFF
--- a/Posh-ACME/DnsPlugins/Windows.ps1
+++ b/Posh-ACME/DnsPlugins/Windows.ps1
@@ -30,12 +30,12 @@ function Add-DnsTxtWindows {
     # separate the portion of the name that doesn't contain the zone name
     $recShort = $RecordName.Replace(".$ZoneName",'')
 
-    $recs = @($zone | Get-DnsServerResourceRecord -Name $recShort -RRType Txt -EA SilentlyContinue)
+    $recs = @($zone | Get-DnsServerResourceRecord -Name $recShort -RRType Txt @dnsParams -EA SilentlyContinue)
 
     if ($recs.Count -eq 0 -or $TxtValue -notin $recs.RecordData.DescriptiveText) {
         # create new
         Write-Verbose "Adding a TXT record for $RecordName with value $TxtValue"
-        $zone | Add-DnsServerResourceRecord -Txt -Name $recShort -DescriptiveText $TxtValue -TimeToLive 00:00:10
+        $zone | Add-DnsServerResourceRecord -Txt -Name $recShort -DescriptiveText $TxtValue -TimeToLive 00:00:10 @dnsParams
     } else {
         # nothing to do
         Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
@@ -108,13 +108,13 @@ function Remove-DnsTxtWindows {
     # separate the portion of the name that doesn't contain the zone name
     $recShort = $RecordName.Replace(".$ZoneName",'')
 
-    $recs = @($zone | Get-DnsServerResourceRecord -Name $recShort -RRType Txt -EA SilentlyContinue)
+    $recs = @($zone | Get-DnsServerResourceRecord -Name $recShort -RRType Txt @dnsParams -EA SilentlyContinue)
 
     if ($recs.Count -gt 0 -and $TxtValue -in $recs.RecordData.DescriptiveText) {
         # remove the record that has the right value
         $toDelete = $recs | Where-Object { $_.RecordData.DescriptiveText -eq $TxtValue }
         Write-Verbose "Deleting $RecordName with value $TxtValue"
-        $zone | Remove-DnsServerResourceRecord -InputObject $toDelete -Force
+        $zone | Remove-DnsServerResourceRecord -InputObject $toDelete -Force @dnsParams
     } else {
         # nothing to do
         Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."


### PR DESCRIPTION
This change fixes the Windows plugin when used on remote DNS servers in a Windows domain.

Before this, calling
```
New-PACertificate name.example.com -DnsPlugin Windows -PluginArgs @{WinServer='dns.example.com'}
```
would give the error message:
```
Add-DnsServerResourceRecord : Failed to get the zone information for example.com on server NAME.
At C:\Program Files\WindowsPowerShell\Modules\Posh-ACME\2.9.1\DnsPlugins\Windows.ps1:38 char:17
+ ...     $zone | Add-DnsServerResourceRecord -Txt -Name $recShort -Descrip ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (_acme-challenge.name:root/Microsoft/...rResourceRecord) [Add-DnsServerResourceRecord], CimException
    + FullyQualifiedErrorId : WIN32 1722,Add-DnsServerResourceRecord
```
and fail with:
```
Authorization invalid for name.example.com: DNS problem: NXDOMAIN looking up TXT for _acme-challenge.name.example.com
At C:\Program Files\WindowsPowerShell\Modules\Posh-ACME\2.9.1\Private\Wait-AuthValidation.ps1:34 char:17
+ ...             throw "Authorization invalid for $($auth.fqdn): $message" ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Authorization i...example.com:String) [], RuntimeException
    + FullyQualifiedErrorId : Authorization invalid for name.example.com: DNS problem: NXDOMAIN looking up TXT for _acme-challenge.name.example.com
```