### PR TITLE
Add REST support to Route53 so AwsPowershell module is not required

### DIFF
--- a/Posh-ACME/DnsPlugins/Route53-Readme.md
+++ b/Posh-ACME/DnsPlugins/Route53-Readme.md
@@ -1,6 +1,8 @@
 # How To Use the Route53 DNS Plugin
 
-This plugin works against the [AWS Route53](https://aws.amazon.com/route53/) DNS provider. It is assumed that you already have an AWS account with at least one DNS zone, and access to create IAM users/roles. The commands used in this guide will also make use of the [AwsPowershell](https://www.powershellgallery.com/packages/AWSPowerShell) or [AwsPowershell.NetCore](https://www.powershellgallery.com/packages/AWSPowerShell.NetCore) module depending on your environment. Currently, they are also required in order to use the plugin.
+This plugin works against the [AWS Route53](https://aws.amazon.com/route53/) DNS provider. It is assumed that you already have an AWS account with at least one DNS zone, and access to create IAM users/roles. The commands used in this guide will also make use of the [AwsPowershell](https://www.powershellgallery.com/packages/AWSPowerShell) or [AwsPowershell.NetCore](https://www.powershellgallery.com/packages/AWSPowerShell.NetCore) module depending on your environment.
+
+The `AwsPowershell` module is *not required* in order to use the plugin normally as long as you use the keys method of authentication. But it will use the module if it's installed.
 
 ## Setup
 
@@ -90,7 +92,7 @@ New-PACertificate test.example.com -DnsPlugin Route53 -PluginArgs $r53Params
 
 ### AwsPowershell Profile (any OS)
 
-The other method uses the `R53ProfileName` parameter to specify the profile name of an existing credential stored with `Set-AwsCredential` from the AWS powershell module.
+The other method uses the `R53ProfileName` parameter to specify the profile name of an existing credential stored with `Set-AwsCredential` from the AWS powershell module. Remember that the `AwsPowershell` module must remain installed for renewals when using this method.
 
 ```powershell
 # store the access/secret key in a profile called 'poshacme'

--- a/Posh-ACME/DnsPlugins/Route53.ps1
+++ b/Posh-ACME/DnsPlugins/Route53.ps1
@@ -18,60 +18,72 @@ function Add-DnsTxtRoute53 {
         $ExtraParams
     )
 
-    # For now, we're going to use the AwsPowershell module for both types of credentials.
-    # But my hope is to eventually remove the AwsPowershell module dependency (which is
-    # currently 75 MB by itself) for people who use the Access/Secret key pair.
-
-    # make sure the correct module is available for the PS edition
-    if ($PSEdition -eq 'Core') { $modName = 'AwsPowershell.NetCore' } else { $modName = 'AwsPowershell' }
-    if (!(Get-Module -ListAvailable $modName -Verbose:$false)) {
-        throw "The $modName module is required to use this plugin."
-    } else {
-        Import-Module $modName -Verbose:$false
-    }
-
-    switch ($PSCmdlet.ParameterSetName) {
-        'Keys' {
-            $keyPlain = (New-Object PSCredential "user",$R53SecretKey).GetNetworkCredential().Password
-            $credParam = @{AccessKey=$R53AccessKey; SecretKey=$keyPlain}
-            break
-        }
-        'KeysInsecure' {
-            $credParam = @{AccessKey=$R53AccessKey; SecretKey=$R53SecretKeyInsecure}
-            break
-        }
-        default {
-            $credParam = @{ProfileName=$R53ProfileName}
-        }
-    }
+    Initialize-R53Config @PSBoundParameters
 
     Write-Verbose "Attempting to find hosted zone for $RecordName"
-    if (!($zoneID = Get-R53ZoneId $RecordName $credParam)) {
+    if (!($zoneID = Get-R53ZoneId $RecordName)) {
         throw "Unable to find Route53 hosted zone for $RecordName"
     }
 
-    # It's possible there could already be a TXT record for this name with one or more existing
-    # values and we don't want to overwrite them. So check first and add to it if it exists.
-    $response = Get-R53ResourceRecordSet $zoneID $RecordName 'TXT' @credParam
-    $rrSet = $response.ResourceRecordSets | Where-Object { $_.Name -eq "$RecordName." -and $_.Type -eq 'TXT' }
-    if ($rrSet.ResourceRecords) {
-        # add to the existing record
-        $rrSet.ResourceRecords += @{Value="`"$TxtValue`""}
+    if ($script:AwsUseModule) {
+
+        # Check for an existing TXT record with this name
+        $response = Get-R53ResourceRecordSet $zoneID $RecordName 'TXT' @script:AwsCredParam
+        $rrSet = $response.ResourceRecordSets | Where-Object { $_.Name -eq "$RecordName." -and $_.Type -eq 'TXT' }
+
+        if ($rrSet) {
+            if ("`"$TxtValue`"" -in $rrSet.ResourceRecords.Value) {
+                Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
+                return
+            }
+            # add a value the existing record
+            $rrSet.ResourceRecords += @{Value="`"$TxtValue`""}
+        } else {
+            # create a new rrset
+            $rrSet = New-Object Amazon.Route53.Model.ResourceRecordSet
+            $rrSet.Name = $RecordName
+            $rrSet.Type = 'TXT'
+            $rrSet.TTL = 60
+            $rrSet.ResourceRecords.Add(@{Value="`"$TxtValue`""})
+        }
+
+        # send the change
+        Write-Verbose "Adding the record to zone ID $zoneID"
+        $change = New-Object Amazon.Route53.Model.Change
+        $change.Action = 'UPSERT'
+        $change.ResourceRecordSet = $rrSet
+        $null = Edit-R53ResourceRecordSet -HostedZoneId $zoneID -ChangeBatch_Change $change @script:AwsCredParam
+
     } else {
-        # create a new one
-        $rrSet = New-Object Amazon.Route53.Model.ResourceRecordSet
-        $rrSet.Name = $RecordName
-        $rrSet.Type = 'TXT'
-        $rrSet.TTL = 0
-        $rrSet.ResourceRecords.Add(@{Value="`"$TxtValue`""})
+
+        # Check for an existing TXT record with this name
+        $ep = "/2013-04-01$zoneID/rrset"
+        $qs = "name=$RecordName&type=TXT"
+        $response = (Invoke-R53RestMethod -Endpoint $ep -QueryString $qs @script:AwsCredParam).ListResourceRecordSetsResponse
+        $rrSet = $response.ResourceRecordSets.ResourceRecordSet | Where-Object { $_.Name -eq "$RecordName." -and $_.Type -eq 'TXT' }
+
+        if ($rrSet) {
+            if ("`"$TxtValue`"" -in $rrSet.ResourceRecords.ResourceRecord.Value) {
+                Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
+                return
+            }
+
+            # parse out the list of <RecordSet> elements that we'll be appending to
+            # There's probably a more elegant way to do this via builtin methods or xpath, but I'm lazy
+            $rrSetXml = $rrSet.OuterXml
+            $iStart = $rrSetXml.IndexOf('<ResourceRecord>')
+            $rrXml = $rrSetXml.Substring($iStart)
+            $iEnd = $rrXml.IndexOf('</ResourceRecords>')
+            $rrXml = $rrXml.Substring(0,$iEnd)
+        }
+
+        # build the UPSERT xml
+        $xmlBody = "<ChangeResourceRecordSetsRequest xmlns=`"https://route53.amazonaws.com/doc/2013-04-01/`"><ChangeBatch><Changes><Change><Action>UPSERT</Action><ResourceRecordSet><Name>$RecordName</Name><Type>TXT</Type><TTL>300</TTL><ResourceRecords>$rrXml<ResourceRecord><Value>`"$TxtValue`"</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>"
+
+        # send the update
+        $null = Invoke-R53RestMethod -Endpoint $ep -UsePost -Data $xmlBody @script:AwsCredParam
     }
 
-    # send the change
-    Write-Verbose "Adding the record to zone ID $zoneID"
-    $change = New-Object Amazon.Route53.Model.Change
-    $change.Action = 'UPSERT'
-    $change.ResourceRecordSet = $rrSet
-    Edit-R53ResourceRecordSet -HostedZoneId $zoneID -ChangeBatch_Change $change @credParam | Out-Null
 
     <#
     .SYNOPSIS
@@ -139,54 +151,79 @@ function Remove-DnsTxtRoute53 {
         $ExtraParams
     )
 
-    # For now, we're going to use the AwsPowershell module for both types of credentials.
-    # But my hope is to eventually remove the AwsPowershell module dependency (which is
-    # currently 75 MB by itself) for people who use the Access/Secret key pair.
-
-    switch ($PSCmdlet.ParameterSetName) {
-        'Keys' {
-            $keyPlain = (New-Object PSCredential "user",$R53SecretKey).GetNetworkCredential().Password
-            $credParam = @{AccessKey=$R53AccessKey; SecretKey=$keyPlain}
-            break
-        }
-        'KeysInsecure' {
-            $credParam = @{AccessKey=$R53AccessKey; SecretKey=$R53SecretKeyInsecure}
-            break
-        }
-        default {
-            $credParam = @{ProfileName=$R53ProfileName}
-        }
-    }
-
+    Initialize-R53Config @PSBoundParameters
 
     Write-Verbose "Attempting to find hosted zone for $RecordName"
-    if (!($zoneID = Get-R53ZoneId $RecordName $credParam)) {
+    if (!($zoneID = Get-R53ZoneId $RecordName)) {
         throw "Unable to find Route53 hosted zone for $RecordName"
     }
 
-    # The TXT record for this name could potentially have multiple values and we only want to
-    # remove this specific one.
-    $response = Get-R53ResourceRecordSet $zoneID $RecordName 'TXT' @credParam
-    $rrSet = $response.ResourceRecordSets | Where-Object { $_.Name -eq "$RecordName." -and $_.Type -eq 'TXT' }
+    if ($script:AwsUseModule) {
 
-    $change = New-Object Amazon.Route53.Model.Change
-    $change.ResourceRecordSet = $rrSet
+        # Check for an existing TXT record with this name
+        $response = Get-R53ResourceRecordSet $zoneID $RecordName 'TXT' @script:AwsCredParam
+        $rrSet = $response.ResourceRecordSets | Where-Object { $_.Name -eq "$RecordName." -and $_.Type -eq 'TXT' }
 
-    if (!$rrSet) {
-        Write-Verbose "TXT record for $Record name not found. Already deleted?"
-        return
-    } elseif ($rrSet.ResourceRecords.Count -gt 1) {
-        # update the values to exclude one we want to delete
-        $change.Action = 'UPSERT'
-        $rrSet.ResourceRecords = $rrSet.ResourceRecords | Where-Object { $_.Value -ne "`"$TxtValue`"" }
+        if (-not $rrSet -or "`"$TxtValue`"" -notin $rrSet.ResourceRecords.Value) {
+            Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."
+            return
+        } else {
+            # begin a change request
+            $change = New-Object Amazon.Route53.Model.Change
+            $change.ResourceRecordSet = $rrSet
+
+            if ($rrSet.ResourceRecords.Count -gt 1) {
+                # update the values to exclude one we want to delete
+                $change.Action = 'UPSERT'
+                $rrSet.ResourceRecords = $rrSet.ResourceRecords | Where-Object { $_.Value -ne "`"$TxtValue`"" }
+            } else {
+                # just delete the record
+                $change.Action = 'DELETE'
+            }
+
+            # remove the record
+            Write-Verbose "Removing the record from zone ID $zoneID"
+            $null = Edit-R53ResourceRecordSet -HostedZoneId $zoneID -ChangeBatch_Change $change @script:AwsCredParam
+        }
+
     } else {
-        # just delete the record
-        $change.Action = 'DELETE'
+
+        # Check for an existing TXT record with this name
+        $ep = "/2013-04-01$zoneID/rrset"
+        $qs = "name=$RecordName&type=TXT"
+        $response = (Invoke-R53RestMethod -Endpoint $ep -QueryString $qs @script:AwsCredParam).ListResourceRecordSetsResponse
+        $rrSet = $response.ResourceRecordSets.ResourceRecordSet | Where-Object { $_.Name -eq "$RecordName." -and $_.Type -eq 'TXT' }
+
+        if (-not $rrSet -or "`"$TxtValue`"" -notin $rrSet.ResourceRecords.ResourceRecord.Value) {
+            Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."
+            return
+        } else {
+
+            # parse out the list of <RecordSet> elements that we'll be removing from
+            # There's probably a more elegant way to do this via builtin methods or xpath, but I'm lazy
+            $rrSetXml = $rrSet.OuterXml
+            $iStart = $rrSetXml.IndexOf('<ResourceRecord>')
+            $rrXml = $rrSetXml.Substring($iStart)
+            $iEnd = $rrXml.IndexOf('</ResourceRecords>')
+            $rrXml = $rrXml.Substring(0,$iEnd)
+
+            # check if this is the last value or not
+            if (@($rrSet.ResourceRecords.ResourceRecord).Count -gt 1) {
+                # remove the RecordSet value that we're deleting
+                $rrXml = $rrXml.Replace("<ResourceRecord><Value>`"$TxtValue`"</Value></ResourceRecord>",'')
+                $action = 'UPSERT'
+            } else {
+                $action = 'DELETE'
+            }
+        }
+
+        # build the xml body
+        $xmlBody = "<ChangeResourceRecordSetsRequest xmlns=`"https://route53.amazonaws.com/doc/2013-04-01/`"><ChangeBatch><Changes><Change><Action>$action</Action><ResourceRecordSet><Name>$RecordName</Name><Type>TXT</Type><TTL>300</TTL><ResourceRecords>$rrXml</ResourceRecords></ResourceRecordSet></Change></Changes></ChangeBatch></ChangeResourceRecordSetsRequest>"
+
+        # send the update
+        $null = Invoke-R53RestMethod -Endpoint $ep -UsePost -Data $xmlBody @script:AwsCredParam
     }
 
-    # remove the record
-    Write-Verbose "Removing the record from zone ID $zoneID"
-    Edit-R53ResourceRecordSet -HostedZoneId $zoneID -ChangeBatch_Change $change @credParam | Out-Null
 
     <#
     .SYNOPSIS
@@ -256,6 +293,62 @@ function Save-DnsTxtRoute53 {
 # Helper Functions
 ############################
 
+function Initialize-R53Config {
+    [CmdletBinding(DefaultParameterSetName='Keys')]
+    param (
+        [Parameter(ParameterSetName='Keys',Mandatory,Position=0)]
+        [Parameter(ParameterSetName='KeysInsecure',Mandatory,Position=0)]
+        [string]$R53AccessKey,
+        [Parameter(ParameterSetName='Keys',Mandatory,Position=1)]
+        [securestring]$R53SecretKey,
+        [Parameter(ParameterSetName='KeysInsecure',Mandatory,Position=1)]
+        [string]$R53SecretKeyInsecure,
+        [Parameter(ParameterSetName='Profile',Mandatory)]
+        [string]$R53ProfileName,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParamsConfig
+    )
+
+    # We now have the ability to do direct REST calls against AWS without the AwsPowerShell dependency
+    # as long as the user provided explicit keys rather than a profile name.
+    # However, we're still going to prefer using the module if it's installed because it's less likely
+    # to break over time if AWS updates the REST API requirements. Or rather, fixing it should be as simple
+    # as installing an updated version of the AwsPowerhell module.
+
+    # check for AwsPowershell module availability
+    if ($PSEdition -eq 'Core') { $modName = 'AwsPowershell.NetCore' } else { $modName = 'AwsPowershell2' }
+    $modAvailable = $null -ne (Get-Module -ListAvailable $modName -Verbose:$false)
+    if ($modAvailable) {
+        Import-Module $modName -Verbose:$false
+        $script:AwsUseModule = $true
+    } else {
+        Write-Verbose "The $modName module was not found."
+        $script:AwsUseModule = $false
+    }
+
+    # build and save the credential parameter(s)
+    switch ($PSCmdlet.ParameterSetName) {
+        'Keys' {
+            $secPlain = (New-Object PSCredential "user",$R53SecretKey).GetNetworkCredential().Password
+            $script:AwsCredParam = @{AccessKey=$R53AccessKey; SecretKey=$secPlain}
+            break
+        }
+        'KeysInsecure' {
+            $script:AwsCredParam = @{AccessKey=$R53AccessKey; SecretKey=$R53SecretKeyInsecure}
+            break
+        }
+        default {
+            # the only thing left is profile name which requires the module
+            # so error if we didn't find it
+            if (-not $modAvailable) {
+                throw "The $modName module is required to use this plugin with the R53ProfileName parameter."
+            }
+            $script:AwsCredParam = @{ProfileName=$R53ProfileName}
+        }
+    }
+
+}
+
 function Get-AwsHash {
     [CmdletBinding()]
     param (
@@ -271,17 +364,13 @@ function Get-AwsHash {
 function Invoke-R53RestMethod {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory,Position=0)]
+        [Parameter(Mandatory)]
         [string]$AccessKey,
-        [Parameter(Mandatory,Position=1)]
+        [Parameter(Mandatory)]
         [string]$SecretKey,
-        [Parameter(Position=2)]
-        [string]$Method='GET',
-        [Parameter(Position=3)]
+        [switch]$UsePost,                       # default to GET unless this is used
         [string]$Endpoint='/',                  # e.g. CanonicalUri like "/2013-04-01/hostedzone"
-        [Parameter(Position=4)]
         [string]$QueryString=[String]::Empty,   # e.g. CanonicalQueryString like "name=example.com&type=TXT"
-        [Parameter(Position=5)]
         [string]$Data=[String]::Empty
     )
 
@@ -302,9 +391,9 @@ function Invoke-R53RestMethod {
 
     # https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
     $CanonicalHeaders = "host:$awsHost`nx-amz-date:$nowDateTime`n"
-    Write-Debug "CanonicalHeaders:`n$CanonicalHeaders"
     $SignedHeaders = "host;x-amz-date"
 
+    $Method = if ($UsePost) { 'POST' } else { 'GET' }
     $CanonicalRequest = "$Method`n$Endpoint`n$QueryString`n$CanonicalHeaders`n$SignedHeaders`n$((Get-AwsHash $Data))"
     Write-Debug "CanonicalRequest:`n$CanonicalRequest"
     $CanonicalRequestHash = Get-AwsHash $CanonicalRequest
@@ -332,7 +421,6 @@ function Invoke-R53RestMethod {
     $hmac.Key = $kSigning
     $signature = $hmac.ComputeHash([Text.Encoding]::UTF8.GetBytes($StringToSign))
     $sigHex = ([BitConverter]::ToString($signature) -replace '-','').ToLower()
-    Write-Debug "Signature:`n$sigHex"
 
     # https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
     $Authorization = "AWS4-HMAC-SHA256 Credential=$AccessKey/$CredentialScope, SignedHeaders=$SignedHeaders, Signature=$sigHex"
@@ -347,13 +435,12 @@ function Invoke-R53RestMethod {
     if ([String]::Empty -ne $QueryString) {
         $uri += "?$QueryString"
     }
-    Write-Debug "Uri: $uri"
 
     try {
-        if ('Get' -eq $Method) {
-            $response = Invoke-RestMethod $uri -Headers $headers @script:UseBasic
+        if ($UsePost) {
+            $response = Invoke-RestMethod $uri -Headers $headers -Method Post -Body $Data @script:UseBasic
         } else {
-            $response = Invoke-RestMethod $uri -Headers $headers -Method Post @script:UseBasic
+            $response = Invoke-RestMethod $uri -Headers $headers @script:UseBasic
         }
         return $response
 
@@ -364,9 +451,7 @@ function Get-R53ZoneId {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]$RecordName,
-        [Parameter(Mandatory,Position=1)]
-        [hashtable]$CredParam
+        [string]$RecordName
     )
 
     # setup a module variable to cache the record to zone ID mapping
@@ -378,18 +463,27 @@ function Get-R53ZoneId {
         return $script:R53RecordZones.$RecordName
     }
 
-    # get the list of available public zones
-    $zones = Get-R53HostedZoneList @CredParam | Where-Object { -not $_.Config.PrivateZone }
+    # Since there's no good way to query the existence of a single zone, we have to fetch all of them
+    if ($script:AwsUseModule) {
+        # fetch via Module
+        $zones = Get-R53HostedZoneList @script:AwsCredParam | Where-Object { $_.Config.PrivateZone -eq $false }
+    } else {
+        # fetch via REST
+        $zones = @()
+        $nextMarker = ''
+        do {
+            $response = (Invoke-R53RestMethod @script:AwsCredParam -Endpoint '/2013-04-01/hostedzone' -QueryString $nextMarker).ListHostedZonesResponse
+            $zones += @(($response.HostedZones.HostedZone | Where-Object { $_.Config.PrivateZone -eq 'false' }))
 
-    # Since Route53 could be hosting both apex and sub-zones, we need to find the closest/deepest
-    # sub-zone that would hold the record rather than just adding it to the apex. So for something
-    # like _acme-challenge.site1.sub1.sub2.example.com, we'd look for zone matches in the following
-    # order:
-    # - site1.sub1.sub2.example.com
-    # - sub1.sub2.example.com
-    # - sub2.example.com
-    # - example.com
+            # check for paging
+            if ([String]::IsNullOrWhiteSpace($response.NextMarker)) { break }
+            $nextMarker = "marker=$($response.NextMarker)&"
+        } while ($true)
+    }
+    Write-Debug "Total zones: $($zones.Count)"
 
+    # Loop through increasingly general sub-zones to find the most specific
+    # zone this record should live in.
     $pieces = $RecordName.Split('.')
     for ($i=1; $i -lt ($pieces.Count-1); $i++) {
         $zoneTest = "$( $pieces[$i..($pieces.Count-1)] -join '.' )."


### PR DESCRIPTION
This change addesses issue #115 in order to remove the dependence on the `AwsPowershell` module when using the plugin. It will still prefer and use the module if it's installed and it is still required when using the `R53ProfileName` authentication method.

It utilizes [AWS Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html) which is the latest as of today.