### PR TITLE
Support supplying new PluginArgs on renewal

### DIFF
--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -167,6 +167,9 @@ function Submit-Renewal {
     .PARAMETER NoSkipManualDns
         If specified, orders that utilize the Manual DNS plugin will not be skipped and user interaction may be required to complete the process. Otherwise, orders that utilize the Manual DNS plugin will be skipped.
 
+    .PARAMETER PluginArgs
+        A hashtable containing an updated set of plugin arguments to use with the renewal. So if a plugin has a -MyText string and -MyNumber integer parameter, you could specify them as @{MyText='text';MyNumber=1234}.
+
     .EXAMPLE
         Submit-Renewal
 

--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -9,7 +9,8 @@ function Submit-Renewal {
         [switch]$AllAccounts,
         [switch]$NewKey,
         [switch]$Force,
-        [switch]$NoSkipManualDns
+        [switch]$NoSkipManualDns,
+        [hashtable]$PluginArgs
     )
 
     Begin {
@@ -73,6 +74,12 @@ function Submit-Renewal {
                     $certParams.CSRPath = $reqPath
                 }
                 $certParams.DnsPlugin = $order.DnsPlugin
+
+                # If new PluginArgs were specified, store these now.
+                if ($PluginArgs) {
+                    Export-PluginArgs $PluginArgs $order.DnsPlugin (Get-PAAccount)
+                }
+
                 $certParams.PluginArgs = Import-PluginArgs $order.DnsPlugin
                 $certParams.DnsAlias = $order.DnsAlias
                 $certParams.Force = $Force.IsPresent

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -164,7 +164,7 @@ These are designed to be used in a daily scheduled task. **Make sure to have it 
 
 ### Updating DNS Plugin Parameters on Renewal
 
-If you are authenticating to your DNS provider using a short-lived access token, you may need to update said token when it comes to renewal. You can do this by specifying the new plugin parameters using the ```-PluginArgs``` parameter. **The full set of plugin arguments must be specified**.
+DNS provider credentials can change over time and some plugins can be used with purposefully short-lived access tokens. In these cases, you can specify the new plugin parameters using the ```-PluginArgs``` parameter. **The full set of plugin arguments must be specified.**
 
 As an example, consider the case for the Azure DNS plugin:
 

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -162,6 +162,17 @@ Submit-Renewal -AllAccounts
 
 These are designed to be used in a daily scheduled task. **Make sure to have it run as the same user you're currently logged in as** because the module config is all stored in your local profile. Each day, it will check the existing certs for ones that have reached the renewal window and renew them. It will just ignore the ones that aren't ready yet.
 
+### Updating DNS Plugin Parameters on Renewal
+
+If you are authenticating to your DNS provider using a short-lived access token, you may need to update said token when it comes to renewal. You can do this by specifying the new plugin parameters using the ```-PluginArgs``` parameter. **The full set of plugin arguments must be specified**.
+
+As an example, consider the case for the Azure DNS plugin:
+
+```powershell
+# renew specifying new plugin arguments
+Submit-Renewal -PluginArgs @{AZSubscriptionId='mysubscriptionid',AZAccessToken='myaccesstoken'}
+```
+
 ## Going Into Production
 
 Now that you've got everything working against the Let's Encrypt staging server, all you have to do is switch over to the production server and re-run your `New-PACertificate` command to get your shiny new publicly trusted certificate.


### PR DESCRIPTION
Consider scenarios where we are using short lived access tokens for authentication to a DNS provider. The previously supplied token will now no longer be valid, therefore it would be good to be able to supply a new set of PluginArgs in the renewal.

This scenario is applicable in CI/CD workflows. I have run into this issue using the Azure DNS plugin where I use az cli to generate an access token to supply to Posh-ACME. I did not want to supply standing credentials as they would be stored in the .config folder as I would have to manage that.

I realise this could be problematic when multiple DNS plugins are used. Another alternative is to make public the ```Export-PluginArgs``` function. This way people can update them before running the ```Submit-Renewal``` command.