### PR TITLE
Azure App Services / Function Apps Storage Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+/.vs/Posh-ACME/v16
+/.vs

--- a/Posh-ACME/Private/Import-PAConfig.ps1
+++ b/Posh-ACME/Private/Import-PAConfig.ps1
@@ -26,8 +26,13 @@ function Import-PAConfig {
     # make sure we have the root config folder
     if ([string]::IsNullOrWhiteSpace((Get-ConfigRoot))) {
         if ($IsWindows -or $PSVersionTable.PSEdition -eq 'Desktop') {
-            Set-ConfigRoot (Join-Path $env:LOCALAPPDATA 'Posh-ACME')
-        } elseif ($IsLinux) {
+			if($env:WEBSITE_INSTANCE_ID -eq $null -or $env:WEBSITE_INSTANCE_ID -eq ""){
+	            Set-ConfigRoot (Join-Path $env:HOME 'Posh-ACME')		
+			}
+			else{
+		        Set-ConfigRoot (Join-Path $env:LOCALAPPDATA 'Posh-ACME')
+			}
+		}elseif ($IsLinux) {
             Set-ConfigRoot (Join-Path $env:HOME '.config/Posh-ACME')
         } elseif ($IsMacOs) {
             Set-ConfigRoot (Join-Path $env:HOME 'Library/Preferences/Posh-ACME')

--- a/Posh-ACME/Private/Import-PAConfig.ps1
+++ b/Posh-ACME/Private/Import-PAConfig.ps1
@@ -26,13 +26,13 @@ function Import-PAConfig {
     # make sure we have the root config folder
     if ([string]::IsNullOrWhiteSpace((Get-ConfigRoot))) {
         if ($IsWindows -or $PSVersionTable.PSEdition -eq 'Desktop') {
-			if($env:WEBSITE_INSTANCE_ID -eq $null -or $env:WEBSITE_INSTANCE_ID -eq ""){
-				Set-ConfigRoot (Join-Path $env:HOME 'Posh-ACME')		
-			}
-			else{
-				Set-ConfigRoot (Join-Path $env:LOCALAPPDATA 'Posh-ACME')
-			}
-		}elseif ($IsLinux) {
+            if($env:WEBSITE_INSTANCE_ID -eq $null -or $env:WEBSITE_INSTANCE_ID -eq ""){
+                Set-ConfigRoot (Join-Path $env:HOME 'Posh-ACME')		
+            }
+            else{
+                Set-ConfigRoot (Join-Path $env:LOCALAPPDATA 'Posh-ACME')
+            }
+        }elseif ($IsLinux) {
             Set-ConfigRoot (Join-Path $env:HOME '.config/Posh-ACME')
         } elseif ($IsMacOs) {
             Set-ConfigRoot (Join-Path $env:HOME 'Library/Preferences/Posh-ACME')

--- a/Posh-ACME/Private/Import-PAConfig.ps1
+++ b/Posh-ACME/Private/Import-PAConfig.ps1
@@ -27,10 +27,10 @@ function Import-PAConfig {
     if ([string]::IsNullOrWhiteSpace((Get-ConfigRoot))) {
         if ($IsWindows -or $PSVersionTable.PSEdition -eq 'Desktop') {
 			if($env:WEBSITE_INSTANCE_ID -eq $null -or $env:WEBSITE_INSTANCE_ID -eq ""){
-	            Set-ConfigRoot (Join-Path $env:HOME 'Posh-ACME')		
+				Set-ConfigRoot (Join-Path $env:HOME 'Posh-ACME')		
 			}
 			else{
-		        Set-ConfigRoot (Join-Path $env:LOCALAPPDATA 'Posh-ACME')
+				Set-ConfigRoot (Join-Path $env:LOCALAPPDATA 'Posh-ACME')
 			}
 		}elseif ($IsLinux) {
             Set-ConfigRoot (Join-Path $env:HOME '.config/Posh-ACME')


### PR DESCRIPTION
In Azure App Services and Function Apps, the LOCALAPPDATA folder is a non persistent storage location. that means it will randomly get wiped by Microsoft. This doesn't work for storing certs and metadata. so they recommend using the HOME env var folder as this is the only persistent storage in App services. 
This code will determine if its on azure app services by using (env var WEBSITE_INSTANCE_ID) which only exists in those services.