### PR TITLE
If bLock skips even when script variable does not exist.

### DIFF
--- a/Posh-ACME/DnsPlugins/Cloudflare.ps1
+++ b/Posh-ACME/DnsPlugins/Cloudflare.ps1
@@ -237,7 +237,7 @@ function Find-CFZone {
 
     $apiRoot = 'https://api.cloudflare.com/client/v4/zones'
 
-    if (-not $script:CFZoneIDs) {
+    if ($script:CFZoneIDs.count -eq 0) {
         $script:CFZoneIDs = @{}
 
         # Due to a bug in the way Cloudflare implemented their limited scope


### PR DESCRIPTION
When debugging #184 I found the block for getting zone records from cloudflare was being completely skipped. Then `$script:CFZoneIDs.ContainsKey($zoneTest)` never returns because it's and empty list of zones.  You can see "checking co.uk" in the debug logs as it fails through the loop.

I'm not clear why `-not $script:CFZoneIDs` doesn't. I presume something about scoping the variable makes it harder to test.