### PR TITLE
Fix Insecure/Non-windows key parameter example

### DIFF
--- a/Posh-ACME/DnsPlugins/NS1-Readme.md
+++ b/Posh-ACME/DnsPlugins/NS1-Readme.md
@@ -20,5 +20,5 @@ New-PACertificate test.example.com -DnsPlugin NS1 -PluginArgs @{NS1Key=$ns1Key}
 ### Non-Windows
 
 ```powershell
-New-PACertificate test.example.com -DnsPlugin NS1 -PluginArgs @{NS1Key='xxxxxxxxxxxx'}
+New-PACertificate test.example.com -DnsPlugin NS1 -PluginArgs @{NS1KeyInsecure='xxxxxxxxxxxx'}
 ```


### PR DESCRIPTION
Update docs to correct the parameter name for the non-secure version of the key