### PR TITLE
DNS Plugin for Hetzner.de

### DIFF
--- a/Posh-ACME/DnsPlugins/Hetzner-Readme.md
+++ b/Posh-ACME/DnsPlugins/Hetzner-Readme.md
@@ -1,0 +1,26 @@
+# How To Use the Hetzner DNS Plugin
+
+This plugin works against the [Hetzner](https://www.hetzner.de/) DNS provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.
+
+## Setup
+
+You will need to generate an API Token if you haven't already done so. Go to [Manage API tokens](https://dns.hetzner.com/settings/api-token) after logging in to the [DNS Console](https://dns.hetzner.comn). Give the token a name and click `Create access token`. Make a note of the token value as you'll need it later and won't be able to retrieve it after this point.
+
+## Using the Plugin
+
+You will need to provide the API Token as a SecureString value to `HetznerToken` or a standard string value to `HetznerTokenInsecure`. The SecureString version can only be used from Windows or any OS running PowerShell 6.2 or later.
+
+### Windows or PS 6.2+
+
+```powershell
+$token = Read-Host "Hetzner Token" -AsSecureString
+$pArgs = @{HetznerToken=$token}
+New-PACertificate example.com -DnsPlugin Hetzner -PluginArgs $pArgs
+```
+
+### Any OS
+
+```powershell
+$pArgs = @{HetznerTokenInsecure='xxxxxxxxxxxxxxxxxxxxxxxxx'}
+New-PACertificate example.com -DnsPlugin Hetzner -PluginArgs $pArgs
+```

--- a/Posh-ACME/DnsPlugins/Hetzner.ps1
+++ b/Posh-ACME/DnsPlugins/Hetzner.ps1
@@ -1,0 +1,315 @@
+Function Add-DnsTxtHetzner {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position = 0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position = 1)]
+        [string]$TxtValue,
+        [Parameter(Mandatory,Position = 2)]
+        [string]$HetznerAPIKey,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders $HetznerAPIKey
+
+    # find matching ZoneID to check, if the records exists already
+    if (-not ($zoneId, $zoneName = Find-HetznerZone -RecordName $RecordName -HetznerApi $apiRoot -AuthHeaders $AuthHeaders)) {
+        throw "Unable zo find matching zone for $RecordName"
+    }
+
+    # Get a list of existing TXT records for this record name
+    try {
+        Write-Verbose "Searching for existing TXT record"
+        $recs = Invoke-RestMethod "$apiRoot/records?zone_id=$zoneId" `
+            -Headers $AuthHeaders -Method Get -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
+    } catch { throw }
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName -ireplace [regex]::Escape(".$zoneName"), [string]::Empty
+    $txtrec = $recs.records | Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort -and $_.value -eq $TxtValue }    
+
+    if ($txtrec) {
+        Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
+    } else {
+        # create request body schema
+        $body = New-Object System.Object
+        $body | Add-Member -type NoteProperty -name name -value $recShort
+        $body | Add-Member -type NoteProperty -name ttl -value ([System.Int32] 600)
+        $body | Add-Member -type NoteProperty -Name type -Value "TXT"
+        $body | Add-Member -type NoteProperty -Name value -Value $TxtValue
+        $body | Add-Member -type NoteProperty -Name zone_id -Value $zoneId
+        $json = $body | ConvertTo-Json
+
+        # check, if TXT-Record exists to add or update the record
+        $txtrec = $recs.records | Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort }
+
+        try {
+            if ($txtrec)
+            {
+                Write-Verbose "Update Record $RecordName ($($txtrec.Id)) with value $TxtValue."
+
+                $response = Invoke-RestMethod -Uri "$apiRoot/records/$($txtrec.Id)" `
+                -Headers $AuthHeaders -Method Put -Body $json -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
+            } else {
+                Write-Verbose "Add Record $RecordName with value $TxtValue."
+
+                $response = Invoke-RestMethod -Uri "$apiRoot/records" `
+                -Headers $AuthHeaders -Method Post -Body $json -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
+            }
+        } catch { throw }
+        if (-not $response.record)
+        {
+             throw "Hetzner API didn't add/update $RecordName"
+        }
+    }
+
+    <#
+    .SYNOPSIS
+        Add a DNS TXT record to Hetzner.
+    .DESCRIPTION
+        Uses the Hetzner DNS API to add or update a DNS TXT record.
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+    .PARAMETER TxtValue
+        The value of the TXT record.
+    .PARAMETER HetznerAPIKey
+        The Hetzner APIKey generated for your account.
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    .EXAMPLE
+        Add-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value'
+
+        Adds or updates the specified TXT record with the specified value.
+    #>    
+}
+
+Function Remove-DnsTxtHetzner {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position = 0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position = 1)]
+        [string]$TxtValue,
+        [Parameter(Mandatory,Position = 2)]
+        [string]$HetznerAPIKey,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders $HetznerAPIKey
+
+    # find matching ZoneID to check, if the records exists already
+    if (-not ($zoneId, $zoneName = Find-HetznerZone -RecordName $RecordName -HetznerApi $apiRoot -AuthHeaders $AuthHeaders)) {
+        throw "Unable zo find matching zone for $RecordName"
+    }
+
+    # Get a list of existing TXT records for this record name
+    try {
+        Write-Verbose "Searching for existing TXT record"
+        $recs = Invoke-RestMethod "$apiRoot/records?zone_id=$zoneId" `
+            -Headers $AuthHeaders -Method Get -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
+    } catch { throw }
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName -ireplace [regex]::Escape(".$zoneName"), [string]::Empty
+    $txtrec = $recs.records | Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort -and $_.value -eq $TxtValue }    
+
+    if ($txtrec) {
+        Write-Verbose "Remove Record $RecordName ($($txtrec.Id)) with value $TxtValue."
+
+        try {
+            Write-Verbose "Removing $RecordName with value $TxtValue"
+            # Invoke-RestMethod -Uri "$apiRoot/records/$($txtrec.Id)" `
+            #    -Headers $AuthHeaders -Method Delete @Script:UseBasic -ErrorAction Stop
+        } catch { throw "Error removing Record" }
+    } else {
+        Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."
+    }
+
+    Write-Verbose "Done!"
+
+    <#
+    .SYNOPSIS
+        Add a DNS TXT record to Hetzner.
+    .DESCRIPTION
+        Uses the Hetzner DNS API to add or update a DNS TXT record.
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+    .PARAMETER TxtValue
+        The value of the TXT record.
+    .PARAMETER HetznerAPIKey
+        The Hetzner APIKey generated for your account.
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    .EXAMPLE
+        Add-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value'
+
+        Adds or updates the specified TXT record with the specified value.
+    #>    
+}
+
+function Save-DnsTxtHetzner {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+    <#
+    .SYNOPSIS
+        Not required.
+    .DESCRIPTION
+        This provider does not require calling this function to commit changes to DNS records.
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    #>
+}
+
+############################
+# Helper Functions
+############################
+
+# API Docs: https://dns.hetzner.com/api-docs/
+
+Function Find-HetznerZone {
+    [CmdletBinding(DefaultParameterSetName='Token')]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$RecordName,
+        [Parameter(ParameterSetName='Token',Mandatory,Position=1)]
+        [Parameter(ParameterSetName='AuthHeader',Mandatory,Position=1)]
+        [Alias("HetznerAuthToken")]
+        [string]$HetznerApi,
+        [Parameter(ParameterSetName='AuthHeader',Mandatory,Position=2)]
+        [hashtable]$AuthHeaders
+    )
+
+    # setup a module variable to cache the record to zone mapping
+    # so it's quicker to find later
+    if (!$script:HetznerRecordZones) { $script:HetznerRecordZones = @{} }
+
+    # check for the record in the cache
+    if ($script:HetznerRecordZones.ContainsKey($RecordName)) {
+        Write-Debug "Result from Cache $($script:HetznerRecordZones.$RecordName.Name)"
+        return @($script:HetznerRecordZones.$RecordName.Id, $script:HetznerRecordZones.$RecordName.Name)
+    }
+
+    if (-not $AuthHeaders) {
+        $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders $HetznerApi
+    }
+
+    # first, get all Zones, Zone to get is identified by 'ZoneID'.
+    try 
+    { 
+        $response = Invoke-RestMethod -Uri "$apiRoot/zones"  `
+            -Headers $AuthHeaders -Method Get -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
+    } 
+    catch 
+    { 
+        if (-not $_.Exception.Response)
+        {
+            Write-Debug $_.Exception
+            throw  
+        } else {
+            throw "Hetzner API Status Error"
+            Write-Debug "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+            Write-Debug "StatusDescription:" $_.Exception.Response.StatusDescription
+        }
+    }
+     
+    # We need to find the closest/deepest
+    # sub-zone that would hold the record rather than just adding it to the apex. So for something
+    # like _acme-challenge.site1.sub1.sub2.example.com, we'd look for zone matches in the following
+    # order:
+    # - site1.sub1.sub2.example.com
+    # - sub1.sub2.example.com
+    # - sub2.example.com
+    # - example.com
+    $pieces = $RecordName.Split('.')
+    for ($i = 1; $i -lt ($pieces.Count - 1); $i++) {
+        $zoneTest = "$( $pieces[$i..($pieces.Count-1)] -join '.' )"
+        Write-Debug "Checking $zoneTest"
+
+        try {
+            $rec = $response.zones | Where-Object {
+                $_.name -eq $zoneTest
+            }
+        }
+        catch {
+            
+        }
+
+        if ($null -eq $rec) { 
+            Write-Debug "Zone $zoneTest does not exist ..."
+        } else {
+            Write-Debug "Zone $zoneTest found."
+
+            $zone = New-Object System.Object
+            $zone | Add-Member -type NoteProperty -name Id -value $rec.id
+            $zone | Add-Member -type NoteProperty -name Name -value $zoneTest
+
+            $script:HetznerRecordZones.$RecordName = $zone
+
+            return @($rec.id, $zoneTest)
+        }
+    }
+
+    return $null
+
+    <#      
+    .SYNOPSIS
+        Finds the appropriate DNS zoneID for the supplied record
+    .DESCRIPTION
+        Finds the appropriate DNS zoneID for the supplied record. 
+    .NOTES
+        If the HetznerAPI parameter is filled with the Hetzner Auth-API token, the AuthHeaders parameter must not be used. If the Hetzner API parameter is filled with the root URI of the Hetzner DNS service, the AuthHeaders parameter must be used.
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+    .PARAMETER HetznerAPI - Alias HetznerAuthToken
+        The Hetzner Auth-API-Token or the URI if used the AuthHeaders-Parameter.
+    .PARAMETER AuthHeaders
+        The Hetzner Auth-API-Header.
+    .OUTPUTS
+        Array of system.string, system.string. Find-HetznerZone returns an array of the ZoneID and ZoneName
+    .EXAMPLE
+        Find-HetznerZone -RecordName '_acme-challenge.site1.example.com' -HetznerAuthToken 'asdfqwer12345678'
+        Finds the appropriate DNS zoneID for the supplied record using the Hetzner Auth-API-Token
+    .EXAMPLE
+        $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders -HetznerAuthToken 'asdfqwer12345678'   
+        $zoneId, $zoneName = Find-HetznerZone -RecordName '_acme-challenge.site1.example.com' -AuthHeader $AuthHeaders -ApiRoot $apiRoot
+        Finds the appropriate DNS zoneID for the supplied record using the Hetzner Auth-API-Token
+    .EXAMPLE
+        Find-HetznerZone -RecordName '_acme-challenge.site1.example.com' -HetznerApi 'https://dns.hetzner.com/api/v1' -AuthHeader @{'X-Consumer-Username='' 'Auth-API-Token=asdfqwer12345678' } 
+        Finds the appropriate DNS zoneID for the supplied record using the Hetzner root URI and AuthHeaders.
+    #>
+}
+
+Function Get-ApiRootAndAuthHeaders {
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$HetznerAuthToken
+    ) 
+
+    if (-not $HetznerAuthToken) { throw "Parameter HetznerAuthTocken is missing." }
+
+    $apiRoot = 'https://dns.hetzner.com/api/v1' 
+
+    $AuthHeaders = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+    $AuthHeaders.Add("X-Consumer-Username", '')
+    $AuthHeaders.Add("Auth-API-Token", $HetznerAuthToken)
+
+    return @($apiRoot, $AuthHeaders)
+
+    <#      
+    .SYNOPSIS
+        Returns the required parameters for DNS API and header parameters
+    .DESCRIPTION
+        Returns the required parameters for DNS API and header parameters
+     .PARAMETER HetznerAuthToken
+        The Hetzner Auth-API-Token.
+   .EXAMPLE
+        $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders -HetznerAuthToken 'asdfqwer12345678'
+
+        Return the appropriate Uri amd Header Parameter
+    #>
+}

--- a/Posh-ACME/DnsPlugins/Hetzner.ps1
+++ b/Posh-ACME/DnsPlugins/Hetzner.ps1
@@ -1,67 +1,74 @@
 Function Add-DnsTxtHetzner {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Secure')]
     param(
         [Parameter(Mandatory,Position = 0)]
         [string]$RecordName,
         [Parameter(Mandatory,Position = 1)]
         [string]$TxtValue,
-        [Parameter(Mandatory,Position = 2)]
-        [string]$HetznerAPIKey,
+        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [securestring]$HetznerToken,
+        [Parameter(ParameterSetName='Insecure',Mandatory,Position=2)]
+        [string]$HetznerTokenInsecure,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
 
-    $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders $HetznerAPIKey
+    $apiRoot = 'https://dns.hetzner.com/api/v1'
+
+    # un-secure the password so we can add it to the auth header
+    if ('Secure' -eq $PSCmdlet.ParameterSetName) {
+        $HetznerTokenInsecure = (New-Object PSCredential "user",$HetznerToken).GetNetworkCredential().Password
+    }
+    $restParams = @{
+        Headers = @{
+            'X-Consumer-Username' = ''
+            'Auth-API-Token' = $HetznerTokenInsecure
+            Accept = 'application/json'
+        }
+        ContentType = 'application/json'
+    }
 
     # find matching ZoneID to check, if the records exists already
-    if (-not ($zoneId, $zoneName = Find-HetznerZone -RecordName $RecordName -HetznerApi $apiRoot -AuthHeaders $AuthHeaders)) {
-        throw "Unable zo find matching zone for $RecordName"
+    if (-not ($zone = Find-HetznerZone $RecordName $restParams)) {
+        throw "Unable to find matching zone for $RecordName"
     }
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName -ireplace [regex]::Escape(".$($zone.name)"), [string]::Empty
 
     # Get a list of existing TXT records for this record name
     try {
         Write-Verbose "Searching for existing TXT record"
-        $recs = Invoke-RestMethod "$apiRoot/records?zone_id=$zoneId" `
-            -Headers $AuthHeaders -Method Get -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
+        $recs = Invoke-RestMethod "$apiRoot/records?zone_id=$($zone.id)" `
+            @restParams @Script:UseBasic -EA Stop
     } catch { throw }
 
-    # separate the portion of the name that doesn't contain the zone name
-    $recShort = $RecordName -ireplace [regex]::Escape(".$zoneName"), [string]::Empty
-    $txtrec = $recs.records | Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort -and $_.value -eq $TxtValue }    
+    # check for a matching record
+    $rec = $recs.records | Where-Object {
+        $_.type -eq 'TXT' -and
+        $_.name -eq $recShort -and
+        $_.value -eq $TxtValue
+    }
 
-    if ($txtrec) {
+    if ($rec) {
         Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
     } else {
         # create request body schema
-        $body = New-Object System.Object
-        $body | Add-Member -type NoteProperty -name name -value $recShort
-        $body | Add-Member -type NoteProperty -name ttl -value ([System.Int32] 600)
-        $body | Add-Member -type NoteProperty -Name type -Value "TXT"
-        $body | Add-Member -type NoteProperty -Name value -Value $TxtValue
-        $body | Add-Member -type NoteProperty -Name zone_id -Value $zoneId
+        $body = @{
+            name = $recShort
+            ttl = 600
+            type = 'TXT'
+            value = $TxtValue
+            zone_id = $zone.id
+        }
         $json = $body | ConvertTo-Json
 
-        # check, if TXT-Record exists to add or update the record
-        $txtrec = $recs.records | Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort }
-
         try {
-            if ($txtrec)
-            {
-                Write-Verbose "Update Record $RecordName ($($txtrec.Id)) with value $TxtValue."
+            Write-Verbose "Add Record $RecordName with value $TxtValue."
 
-                $response = Invoke-RestMethod -Uri "$apiRoot/records/$($txtrec.Id)" `
-                -Headers $AuthHeaders -Method Put -Body $json -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
-            } else {
-                Write-Verbose "Add Record $RecordName with value $TxtValue."
-
-                $response = Invoke-RestMethod -Uri "$apiRoot/records" `
-                -Headers $AuthHeaders -Method Post -Body $json -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
-            }
+            Invoke-RestMethod "$apiRoot/records" -Method Post -Body $json `
+                @restParams @Script:UseBasic -EA Stop | Out-Null
         } catch { throw }
-        if (-not $response.record)
-        {
-             throw "Hetzner API didn't add/update $RecordName"
-        }
     }
 
     <#
@@ -73,80 +80,101 @@ Function Add-DnsTxtHetzner {
         The fully qualified name of the TXT record.
     .PARAMETER TxtValue
         The value of the TXT record.
-    .PARAMETER HetznerAPIKey
-        The Hetzner APIKey generated for your account.
+    .PARAMETER HetznerToken
+        The API token for your Hetzner account. This SecureString version can only be used on Windows or any OS running PowerShell 6.2 or later.
+    .PARAMETER HetznerTokenInsecure
+        The API token for your Hetzner account. This standard String version may be used on any OS.
     .PARAMETER ExtraParams
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
     .EXAMPLE
-        Add-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value'
+        Add-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value' -HetznerTokenInsecure 'xxxxxxxx'
 
         Adds or updates the specified TXT record with the specified value.
-    #>    
+    #>
 }
 
 Function Remove-DnsTxtHetzner {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Secure')]
     param(
         [Parameter(Mandatory,Position = 0)]
         [string]$RecordName,
         [Parameter(Mandatory,Position = 1)]
         [string]$TxtValue,
-        [Parameter(Mandatory,Position = 2)]
-        [string]$HetznerAPIKey,
+        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [securestring]$HetznerToken,
+        [Parameter(ParameterSetName='Insecure',Mandatory,Position=2)]
+        [string]$HetznerTokenInsecure,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
 
-    $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders $HetznerAPIKey
+    $apiRoot = 'https://dns.hetzner.com/api/v1'
+
+    # un-secure the password so we can add it to the auth header
+    if ('Secure' -eq $PSCmdlet.ParameterSetName) {
+        $HetznerTokenInsecure = (New-Object PSCredential "user",$HetznerToken).GetNetworkCredential().Password
+    }
+    $restParams = @{
+        Headers = @{
+            'X-Consumer-Username' = ''
+            'Auth-API-Token' = $HetznerTokenInsecure
+            Accept = 'application/json'
+        }
+        ContentType = 'application/json'
+    }
 
     # find matching ZoneID to check, if the records exists already
-    if (-not ($zoneId, $zoneName = Find-HetznerZone -RecordName $RecordName -HetznerApi $apiRoot -AuthHeaders $AuthHeaders)) {
-        throw "Unable zo find matching zone for $RecordName"
+    if (-not ($zone = Find-HetznerZone $RecordName $restParams)) {
+        throw "Unable to find matching zone for $RecordName"
     }
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName -ireplace [regex]::Escape(".$($zone.name)"), [string]::Empty
 
     # Get a list of existing TXT records for this record name
     try {
         Write-Verbose "Searching for existing TXT record"
-        $recs = Invoke-RestMethod "$apiRoot/records?zone_id=$zoneId" `
-            -Headers $AuthHeaders -Method Get -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
+        $recs = Invoke-RestMethod "$apiRoot/records?zone_id=$($zone.id)" `
+            @restParams @Script:UseBasic -EA Stop
     } catch { throw }
 
-    # separate the portion of the name that doesn't contain the zone name
-    $recShort = $RecordName -ireplace [regex]::Escape(".$zoneName"), [string]::Empty
-    $txtrec = $recs.records | Where-Object { $_.type -eq 'TXT' -and $_.name -eq $recShort -and $_.value -eq $TxtValue }    
+    # check for a matching record
+    $rec = $recs.records | Where-Object {
+        $_.type -eq 'TXT' -and
+        $_.name -eq $recShort -and
+        $_.value -eq $TxtValue
+    }
 
-    if ($txtrec) {
-        Write-Verbose "Remove Record $RecordName ($($txtrec.Id)) with value $TxtValue."
-
+    if ($rec) {
         try {
-            Write-Verbose "Removing $RecordName with value $TxtValue"
-            # Invoke-RestMethod -Uri "$apiRoot/records/$($txtrec.Id)" `
-            #    -Headers $AuthHeaders -Method Delete @Script:UseBasic -ErrorAction Stop
-        } catch { throw "Error removing Record" }
+            Write-Verbose "Remove Record $RecordName ($($rec.Id)) with value $TxtValue."
+            Invoke-RestMethod "$apiRoot/records/$($rec.Id)" -Method Delete `
+               @restParams @Script:UseBasic -EA Stop | Out-Null
+        } catch { throw }
     } else {
         Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."
     }
 
-    Write-Verbose "Done!"
-
     <#
     .SYNOPSIS
-        Add a DNS TXT record to Hetzner.
+        Remove a DNS TXT record from Hetzner.
     .DESCRIPTION
-        Uses the Hetzner DNS API to add or update a DNS TXT record.
+        Uses the Hetzner DNS API to remove DNS TXT record.
     .PARAMETER RecordName
         The fully qualified name of the TXT record.
     .PARAMETER TxtValue
         The value of the TXT record.
-    .PARAMETER HetznerAPIKey
-        The Hetzner APIKey generated for your account.
+    .PARAMETER HetznerToken
+        The API token for your Hetzner account. This SecureString version can only be used on Windows or any OS running PowerShell 6.2 or later.
+    .PARAMETER HetznerTokenInsecure
+        The API token for your Hetzner account. This standard String version may be used on any OS.
     .PARAMETER ExtraParams
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
     .EXAMPLE
-        Add-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value'
+        Remove-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value' -HetznerTokenInsecure 'xxxxxxxx'
 
-        Adds or updates the specified TXT record with the specified value.
-    #>    
+        Removes the specified TXT record with the specified value.
+    #>
 }
 
 function Save-DnsTxtHetzner {
@@ -172,16 +200,12 @@ function Save-DnsTxtHetzner {
 # API Docs: https://dns.hetzner.com/api-docs/
 
 Function Find-HetznerZone {
-    [CmdletBinding(DefaultParameterSetName='Token')]
+    [CmdletBinding()]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position=0)]
         [string]$RecordName,
-        [Parameter(ParameterSetName='Token',Mandatory,Position=1)]
-        [Parameter(ParameterSetName='AuthHeader',Mandatory,Position=1)]
-        [Alias("HetznerAuthToken")]
-        [string]$HetznerApi,
-        [Parameter(ParameterSetName='AuthHeader',Mandatory,Position=2)]
-        [hashtable]$AuthHeaders
+        [Parameter(Mandatory, Position=1)]
+        [hashtable]$RestParameters
     )
 
     # setup a module variable to cache the record to zone mapping
@@ -191,32 +215,15 @@ Function Find-HetznerZone {
     # check for the record in the cache
     if ($script:HetznerRecordZones.ContainsKey($RecordName)) {
         Write-Debug "Result from Cache $($script:HetznerRecordZones.$RecordName.Name)"
-        return @($script:HetznerRecordZones.$RecordName.Id, $script:HetznerRecordZones.$RecordName.Name)
-    }
-
-    if (-not $AuthHeaders) {
-        $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders $HetznerApi
+        return $script:HetznerRecordZones.$RecordName
     }
 
     # first, get all Zones, Zone to get is identified by 'ZoneID'.
-    try 
-    { 
-        $response = Invoke-RestMethod -Uri "$apiRoot/zones"  `
-            -Headers $AuthHeaders -Method Get -ContentType "application/json" @Script:UseBasic -ErrorAction Stop
-    } 
-    catch 
-    { 
-        if (-not $_.Exception.Response)
-        {
-            Write-Debug $_.Exception
-            throw  
-        } else {
-            throw "Hetzner API Status Error"
-            Write-Debug "StatusCode:" $_.Exception.Response.StatusCode.value__ 
-            Write-Debug "StatusDescription:" $_.Exception.Response.StatusDescription
-        }
-    }
-     
+    try {
+        $response = Invoke-RestMethod -Uri "https://dns.hetzner.com/api/v1/zones" `
+            @RestParameters @Script:UseBasic -EA Stop
+    } catch { throw }
+
     # We need to find the closest/deepest
     # sub-zone that would hold the record rather than just adding it to the apex. So for something
     # like _acme-challenge.site1.sub1.sub2.example.com, we'd look for zone matches in the following
@@ -230,86 +237,17 @@ Function Find-HetznerZone {
         $zoneTest = "$( $pieces[$i..($pieces.Count-1)] -join '.' )"
         Write-Debug "Checking $zoneTest"
 
-        try {
-            $rec = $response.zones | Where-Object {
-                $_.name -eq $zoneTest
-            }
-        }
-        catch {
-            
-        }
+        $zone = $response.zones | Select-Object id,name |
+            Where-Object { $_.name -eq $zoneTest }
 
-        if ($null -eq $rec) { 
-            Write-Debug "Zone $zoneTest does not exist ..."
-        } else {
+        if ($zone) {
             Write-Debug "Zone $zoneTest found."
-
-            $zone = New-Object System.Object
-            $zone | Add-Member -type NoteProperty -name Id -value $rec.id
-            $zone | Add-Member -type NoteProperty -name Name -value $zoneTest
-
             $script:HetznerRecordZones.$RecordName = $zone
-
-            return @($rec.id, $zoneTest)
+            return $zone
+        } else {
+            Write-Debug "Zone $zoneTest does not exist ..."
         }
     }
 
     return $null
-
-    <#      
-    .SYNOPSIS
-        Finds the appropriate DNS zoneID for the supplied record
-    .DESCRIPTION
-        Finds the appropriate DNS zoneID for the supplied record. 
-    .NOTES
-        If the HetznerAPI parameter is filled with the Hetzner Auth-API token, the AuthHeaders parameter must not be used. If the Hetzner API parameter is filled with the root URI of the Hetzner DNS service, the AuthHeaders parameter must be used.
-    .PARAMETER RecordName
-        The fully qualified name of the TXT record.
-    .PARAMETER HetznerAPI - Alias HetznerAuthToken
-        The Hetzner Auth-API-Token or the URI if used the AuthHeaders-Parameter.
-    .PARAMETER AuthHeaders
-        The Hetzner Auth-API-Header.
-    .OUTPUTS
-        Array of system.string, system.string. Find-HetznerZone returns an array of the ZoneID and ZoneName
-    .EXAMPLE
-        Find-HetznerZone -RecordName '_acme-challenge.site1.example.com' -HetznerAuthToken 'asdfqwer12345678'
-        Finds the appropriate DNS zoneID for the supplied record using the Hetzner Auth-API-Token
-    .EXAMPLE
-        $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders -HetznerAuthToken 'asdfqwer12345678'   
-        $zoneId, $zoneName = Find-HetznerZone -RecordName '_acme-challenge.site1.example.com' -AuthHeader $AuthHeaders -ApiRoot $apiRoot
-        Finds the appropriate DNS zoneID for the supplied record using the Hetzner Auth-API-Token
-    .EXAMPLE
-        Find-HetznerZone -RecordName '_acme-challenge.site1.example.com' -HetznerApi 'https://dns.hetzner.com/api/v1' -AuthHeader @{'X-Consumer-Username='' 'Auth-API-Token=asdfqwer12345678' } 
-        Finds the appropriate DNS zoneID for the supplied record using the Hetzner root URI and AuthHeaders.
-    #>
-}
-
-Function Get-ApiRootAndAuthHeaders {
-    param(
-        [Parameter(Mandatory, Position = 0)]
-        [string]$HetznerAuthToken
-    ) 
-
-    if (-not $HetznerAuthToken) { throw "Parameter HetznerAuthTocken is missing." }
-
-    $apiRoot = 'https://dns.hetzner.com/api/v1' 
-
-    $AuthHeaders = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $AuthHeaders.Add("X-Consumer-Username", '')
-    $AuthHeaders.Add("Auth-API-Token", $HetznerAuthToken)
-
-    return @($apiRoot, $AuthHeaders)
-
-    <#      
-    .SYNOPSIS
-        Returns the required parameters for DNS API and header parameters
-    .DESCRIPTION
-        Returns the required parameters for DNS API and header parameters
-     .PARAMETER HetznerAuthToken
-        The Hetzner Auth-API-Token.
-   .EXAMPLE
-        $apiRoot, $AuthHeaders = Get-ApiRootAndAuthHeaders -HetznerAuthToken 'asdfqwer12345678'
-
-        Return the appropriate Uri amd Header Parameter
-    #>
 }

--- a/Posh-ACME/DnsPlugins/Hetzner.ps1
+++ b/Posh-ACME/DnsPlugins/Hetzner.ps1
@@ -21,7 +21,6 @@ Function Add-DnsTxtHetzner {
     }
     $restParams = @{
         Headers = @{
-            'X-Consumer-Username' = ''
             'Auth-API-Token' = $HetznerTokenInsecure
             Accept = 'application/json'
         }
@@ -88,7 +87,6 @@ Function Add-DnsTxtHetzner {
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
     .EXAMPLE
         Add-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value' -HetznerTokenInsecure 'xxxxxxxx'
-
         Adds or updates the specified TXT record with the specified value.
     #>
 }
@@ -116,7 +114,6 @@ Function Remove-DnsTxtHetzner {
     }
     $restParams = @{
         Headers = @{
-            'X-Consumer-Username' = ''
             'Auth-API-Token' = $HetznerTokenInsecure
             Accept = 'application/json'
         }
@@ -172,7 +169,6 @@ Function Remove-DnsTxtHetzner {
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
     .EXAMPLE
         Remove-DnsTxtHetzner '_acme-challenge.example.com' 'txt-value' -HetznerTokenInsecure 'xxxxxxxx'
-
         Removes the specified TXT record with the specified value.
     #>
 }


### PR DESCRIPTION
# How To Use the Hetzner DNS Plugin

This plugin works against the [Hetzner](https://www.hetzner.de/) DNS provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.

## Finding your information in Hetzner

Using Hetzner DNS API requires only your account name or account number and Auth-API-Token which can be found on the [account](https://dns.hetzner.com/) page.


## Using the Plugin

```powershell
$pArgs = @{ HetznerAPIKey='yyyyyyyy' }
New-PACertificate example.com -DnsPlugin Hetzner -PluginArgs $pArgs
``` 
