### PR TITLE
Filter to only public Google DNS Zones as a private zone won't help.

### DIFF
--- a/Posh-ACME/DnsPlugins/GCloud.ps1
+++ b/Posh-ACME/DnsPlugins/GCloud.ps1
@@ -312,7 +312,7 @@ function Find-GCZone {
     # get the list of available zones
     try {
         $zones = (Invoke-RestMethod "$projRoot/managedZones" `
-            -Headers $script:GCToken.AuthHeader @script:UseBasic).managedZones
+            -Headers $script:GCToken.AuthHeader @script:UseBasic).managedZones | Where-Object {$_.visibility -eq "public"}
     } catch { throw }
 
     # Since Google could be hosting both apex and sub-zones, we need to find the closest/deepest


### PR DESCRIPTION
Fixes #243

Private zones are useless for ACME requests. Ignore them.

Tested under Server 2019 (thanks for the instdev.ps1 script, development wasn't so hard)