### PR TITLE
DNS Plugin: Domain Offensive

### DIFF
--- a/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
+++ b/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
@@ -1,0 +1,22 @@
+# How To Use the Domain Offensive DNS Plugin
+
+This plugin works against the [Domain Offensive](https://www.do.de/) DNS provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.
+
+## Setup
+
+We need to retrieve an secret API token for the account that will be used to update DNS records. Further information can ba found at [the (german) developer docs.](https://www.do.de/wiki/LetsEncrypt_-_Entwickler).
+
+## Using the Plugin
+
+Your personal API token is specified using the generated `Token` parameter.
+The fully qualified name for the TXT record can be specified using the `RecordName` parameter.
+The value for the TXT record can be specified using the `TxtValue` parameter.
+
+```powershell
+$pArgs = @{
+    Token = '1md6xRcUCTrB58kbpwAH',
+    Domain = '_acme-challenge.site1.example.com',
+    TxtValue = 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns'
+}
+New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
+```

--- a/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
+++ b/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
@@ -11,8 +11,15 @@ We need to retrieve an secret API token for the account that will be used to upd
 Your personal API token is specified using the `Token` parameter.
 
 ```powershell
+# Example: Provide the private token via secure string (Windows or any OS with PowerShell 6.2+)
 $pArgs = @{
-    Token = '1md6xRcUCTrB58kbpwAH'
+    DomOffToken = $secureString
+}
+New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
+
+# Alternative Example by directly providing the private token as string
+$pArgs = @{
+    DomOffTokenInsecure = '1md6xRcUCTrB58kbpwAH'
 }
 New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
 ```

--- a/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
+++ b/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
@@ -8,15 +8,11 @@ We need to retrieve an secret API token for the account that will be used to upd
 
 ## Using the Plugin
 
-Your personal API token is specified using the generated `Token` parameter.
-The fully qualified name for the TXT record can be specified using the `RecordName` parameter.
-The value for the TXT record can be specified using the `TxtValue` parameter.
+Your personal API token is specified using the `Token` parameter.
 
 ```powershell
 $pArgs = @{
-    Token = '1md6xRcUCTrB58kbpwAH',
-    Domain = '_acme-challenge.site1.example.com',
-    TxtValue = 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns'
+    Token = '1md6xRcUCTrB58kbpwAH'
 }
 New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
 ```

--- a/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
+++ b/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
@@ -4,7 +4,7 @@ This plugin works against the [Domain Offensive](https://www.do.de/) DNS provide
 
 ## Setup
 
-We need to retrieve an secret API token for the account that will be used to update DNS records. Further information can ba found at [the (german) developer docs.](https://www.do.de/wiki/LetsEncrypt_-_Entwickler).
+We need to retrieve an secret API token for the account that will be used to update DNS records. Further information can ba found at the (german) [developer docs](https://www.do.de/wiki/LetsEncrypt_-_Entwickler).
 
 ## Using the Plugin
 
@@ -13,8 +13,9 @@ Your personal API token is specified using the `DomOffToken` or `DomOffTokenInse
 
 ### Windows and/or PS 6.2+ only (secure string)
 ```powershell
+$secToken = Read-Host -Prompt "Token" -AsSecureString
 $pArgs = @{
-    DomOffToken = $secureString
+    DomOffToken = $secToken
 }
 New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
 ```
@@ -23,7 +24,7 @@ New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
 ### Any OS (default string)
 ```powershell
 $pArgs = @{
-    DomOffTokenInsecure = '1md6xRcUCTrB58kbpwAH'
+    DomOffTokenInsecure = 'token-value'
 }
 New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
 ```

--- a/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
+++ b/Posh-ACME/DnsPlugins/DomainOffensive-Readme.md
@@ -8,16 +8,20 @@ We need to retrieve an secret API token for the account that will be used to upd
 
 ## Using the Plugin
 
-Your personal API token is specified using the `Token` parameter.
+Your personal API token is specified using the `DomOffToken` or `DomOffTokenInsecure` parameter.
 
+
+### Windows and/or PS 6.2+ only (secure string)
 ```powershell
-# Example: Provide the private token via secure string (Windows or any OS with PowerShell 6.2+)
 $pArgs = @{
     DomOffToken = $secureString
 }
 New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
+```
 
-# Alternative Example by directly providing the private token as string
+
+### Any OS (default string)
+```powershell
 $pArgs = @{
     DomOffTokenInsecure = '1md6xRcUCTrB58kbpwAH'
 }

--- a/Posh-ACME/DnsPlugins/DomainOffensive.ps1
+++ b/Posh-ACME/DnsPlugins/DomainOffensive.ps1
@@ -5,14 +5,21 @@ function Add-DnsTxtDomainOffensive {
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
         [string]$TxtValue
-        [Parameter(Mandatory,Position=2)]
-        [string]$Token,
+        [Parameter(ParameterSetName='Secure', Mandatory, Position=2)]
+        [securestring]$DomOffToken,
+        [Parameter(ParameterSetName='Insecure', Mandatory, Position=2)]
+        [string]$DomOffTokenInsecure,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
 
+    # Decrypt the secure string token
+    if ('Secure' -eq $PSCmdlet.ParameterSetName) {
+        $DomOffTokenInsecure = (New-Object PSCredential "user", $DomOffToken).GetNetworkCredential().Password
+    }
+
     Write-Verbose "Adding $RecordName with value $TxtValue on Domain Offensive"
-    $uri = "https://www.do.de/api/letsencrypt?token=$Token&domain=$RecordName&value=$TxtValue"
+    $uri = "https://www.do.de/api/letsencrypt?token=$DomOffTokenInsecure&domain=$RecordName&value=$TxtValue"
     $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic
     
     if (!$response.success) {
@@ -26,8 +33,11 @@ function Add-DnsTxtDomainOffensive {
     .DESCRIPTION
         Add a DNS TXT record to a Domain Offensive DNS Zone
 
-    .PARAMETER Token
-        Token provided by Domain Offensive.
+    .PARAMETER DomOffToken
+        Token as provided by Domain Offensive. This SecureString version should only be used on Windows or any OS with PowerShell 6.2+.
+
+    .PARAMETER DomOffTokenInsecure
+        Token as provided by Domain Offensive. Works on any OS.
 
     .PARAMETER RecordName
         The fully qualified name of the TXT record.
@@ -36,6 +46,8 @@ function Add-DnsTxtDomainOffensive {
         The value of the TXT record.
 
     .EXAMPLE
+        Add-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns' $secureString
+        or
         Add-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns' '1md6xRcUCTrB58kbpwAH'
 
         Adds a TXT record for the specified site with the specified value using the account associated with the given token.
@@ -52,14 +64,21 @@ function Remove-DnsTxtDomainOffensive {
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
         [string]$TxtValue
-        [Parameter(Mandatory,Position=2)]
-        [string]$Token,
+        [Parameter(ParameterSetName='Secure', Mandatory, Position=2)]
+        [securestring]$DomOffToken,
+        [Parameter(ParameterSetName='Insecure', Mandatory, Position=2)]
+        [string]$DomOffTokenInsecure,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
 
+    # Decrypt the secure string token
+    if ('Secure' -eq $PSCmdlet.ParameterSetName) {
+        $DomOffTokenInsecure = (New-Object PSCredential "user", $DomOffToken).GetNetworkCredential().Password
+    }
+
     Write-Verbose "Removing $RecordName with value $TxtValue on Domain Offensive"
-    $uri = "https://www.do.de/api/letsencrypt?token=$Token&domain=$RecordName&action=delete"
+    $uri = "https://www.do.de/api/letsencrypt?token=$DomOffTokenInsecure&domain=$RecordName&action=delete"
     $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic
     
     if (!$response.success) {
@@ -73,13 +92,18 @@ function Remove-DnsTxtDomainOffensive {
     .DESCRIPTION
         Remove a DNS TXT record from Domain Offensive DNS
 
-    .PARAMETER Token
-        Token provided by Domain Offensive.
+    .PARAMETER DomOffToken
+        Token as provided by Domain Offensive. This SecureString version should only be used on Windows or any OS with PowerShell 6.2+.
+
+    .PARAMETER DomOffTokenInsecure
+        Token as provided by Domain Offensive. Works on any OS.
 
     .PARAMETER Domain
         The fully qualified name of the TXT record to be removed.
 
     .EXAMPLE
+        Remove-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' '' $secureString
+        or
         Remove-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' '' '1md6xRcUCTrB58kbpwAH'
 
         Remove the given TXT record from the account associated with the given token.

--- a/Posh-ACME/DnsPlugins/DomainOffensive.ps1
+++ b/Posh-ACME/DnsPlugins/DomainOffensive.ps1
@@ -2,11 +2,13 @@ function Add-DnsTxtDomainOffensive {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]$Token,
-        [Parameter(Mandatory,Position=1)]
         [string]$RecordName,
-        [Parameter(Mandatory,Position=2)]
+        [Parameter(Mandatory,Position=1)]
         [string]$TxtValue
+        [Parameter(Mandatory,Position=2)]
+        [string]$Token,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
     )
 
     Write-Verbose "Adding $RecordName with value $TxtValue on Domain Offensive"
@@ -34,7 +36,7 @@ function Add-DnsTxtDomainOffensive {
         The value of the TXT record.
 
     .EXAMPLE
-        Add-DnsTxtDomainOffensive '1md6xRcUCTrB58kbpwAH' '_acme-challenge.site1.example.com' 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns'
+        Add-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns' '1md6xRcUCTrB58kbpwAH'
 
         Adds a TXT record for the specified site with the specified value using the account associated with the given token.
 
@@ -47,9 +49,13 @@ function Remove-DnsTxtDomainOffensive {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
-        [string]$Token,
+        [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
-        [string]$RecordName
+        [string]$TxtValue
+        [Parameter(Mandatory,Position=2)]
+        [string]$Token,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
     )
 
     Write-Verbose "Removing $RecordName with value $TxtValue on Domain Offensive"
@@ -74,9 +80,9 @@ function Remove-DnsTxtDomainOffensive {
         The fully qualified name of the TXT record to be removed.
 
     .EXAMPLE
-        Add-DnsTxtDomainOffensive '1md6xRcUCTrB58kbpwAH' '_acme-challenge.site1.example.com'
+        Remove-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' '' '1md6xRcUCTrB58kbpwAH'
 
-        Adds a TXT record for the specified site with the specified value using the account associated with the given token.
+        Remove the given TXT record from the account associated with the given token.
 
     .LINK
         https://www.do.de/wiki/LetsEncrypt_-_Entwickler

--- a/Posh-ACME/DnsPlugins/DomainOffensive.ps1
+++ b/Posh-ACME/DnsPlugins/DomainOffensive.ps1
@@ -1,0 +1,103 @@
+function Add-DnsTxtDomainOffensive {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$Token,
+        [Parameter(Mandatory,Position=1)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position=2)]
+        [string]$TxtValue
+    )
+
+    Write-Verbose "Adding $RecordName with value $TxtValue on Domain Offensive"
+    $uri = "https://www.do.de/api/letsencrypt?token=$Token&domain=$RecordName&value=$TxtValue"
+    $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic
+    
+    if (!$response.success) {
+        throw "Failed to add Domain Offensive DNS record; Result=$($response)"
+    }
+    
+    <#
+    .SYNOPSIS
+        Add a DNS TXT record to a Domain Offensive DNS Zone
+
+    .DESCRIPTION
+        Add a DNS TXT record to a Domain Offensive DNS Zone
+
+    .PARAMETER Token
+        Token provided by Domain Offensive.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER TxtValue
+        The value of the TXT record.
+
+    .EXAMPLE
+        Add-DnsTxtDomainOffensive '1md6xRcUCTrB58kbpwAH' '_acme-challenge.site1.example.com' 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns'
+
+        Adds a TXT record for the specified site with the specified value using the account associated with the given token.
+
+    .LINK
+        https://www.do.de/wiki/LetsEncrypt_-_Entwickler
+    #>
+}
+
+function Remove-DnsTxtDomainOffensive {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$Token,
+        [Parameter(Mandatory,Position=1)]
+        [string]$RecordName
+    )
+
+    Write-Verbose "Removing $RecordName with value $TxtValue on Domain Offensive"
+    $uri = "https://www.do.de/api/letsencrypt?token=$Token&domain=$RecordName&action=delete"
+    $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic
+    
+    if (!$response.success) {
+        throw "Failed to remove Domain Offensive DNS record; Result=$($response)"
+    }
+
+    <#
+    .SYNOPSIS
+        Remove a DNS TXT record from Domain Offensive DNS
+
+    .DESCRIPTION
+        Remove a DNS TXT record from Domain Offensive DNS
+
+    .PARAMETER Token
+        Token provided by Domain Offensive.
+
+    .PARAMETER Domain
+        The fully qualified name of the TXT record to be removed.
+
+    .EXAMPLE
+        Add-DnsTxtDomainOffensive '1md6xRcUCTrB58kbpwAH' '_acme-challenge.site1.example.com'
+
+        Adds a TXT record for the specified site with the specified value using the account associated with the given token.
+
+    .LINK
+        https://www.do.de/wiki/LetsEncrypt_-_Entwickler
+    #>
+}
+
+function Save-DnsTxtDomainOffensive {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )    
+
+    <#
+    .SYNOPSIS
+        Not required.
+
+    .DESCRIPTION
+        This provider does not require calling this function to commit changes to DNS records.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    #>
+}

--- a/Posh-ACME/DnsPlugins/DomainOffensive.ps1
+++ b/Posh-ACME/DnsPlugins/DomainOffensive.ps1
@@ -1,10 +1,10 @@
 function Add-DnsTxtDomainOffensive {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Secure')]
     param(
         [Parameter(Mandatory,Position=0)]
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
-        [string]$TxtValue
+        [string]$TxtValue,
         [Parameter(ParameterSetName='Secure', Mandatory, Position=2)]
         [securestring]$DomOffToken,
         [Parameter(ParameterSetName='Insecure', Mandatory, Position=2)]
@@ -20,12 +20,14 @@ function Add-DnsTxtDomainOffensive {
 
     Write-Verbose "Adding $RecordName with value $TxtValue on Domain Offensive"
     $uri = "https://www.do.de/api/letsencrypt?token=$DomOffTokenInsecure&domain=$RecordName&value=$TxtValue"
-    $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic
-    
+    try {
+        $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic -EA Stop
+    } catch { throw }
+
     if (!$response.success) {
         throw "Failed to add Domain Offensive DNS record; Result=$($response)"
     }
-    
+
     <#
     .SYNOPSIS
         Add a DNS TXT record to a Domain Offensive DNS Zone
@@ -46,11 +48,15 @@ function Add-DnsTxtDomainOffensive {
         The value of the TXT record.
 
     .EXAMPLE
-        Add-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns' $secureString
-        or
-        Add-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' 'OVxwaDm7MgN1IRG0eSivJMlepO9CL4X8vKo6Tcns' '1md6xRcUCTrB58kbpwAH'
+        $secToken = Read-Host -Prompt "Token" -AsSecureString
+        PS C:\>Add-DnsTxtDomainOffensive '_acme-challenge.example.com' 'txt-value' $secToken
 
-        Adds a TXT record for the specified site with the specified value using the account associated with the given token.
+        Adds the specified TXT record with the specified value using a secure token.
+
+    .EXAMPLE
+        Add-DnsTxtDomainOffensive '_acme-challenge.example.com' 'txt-value' 'token-value'
+
+        Adds the specified TXT record with the specified value using a standard string token.
 
     .LINK
         https://www.do.de/wiki/LetsEncrypt_-_Entwickler
@@ -58,12 +64,12 @@ function Add-DnsTxtDomainOffensive {
 }
 
 function Remove-DnsTxtDomainOffensive {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Secure')]
     param(
         [Parameter(Mandatory,Position=0)]
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
-        [string]$TxtValue
+        [string]$TxtValue,
         [Parameter(ParameterSetName='Secure', Mandatory, Position=2)]
         [securestring]$DomOffToken,
         [Parameter(ParameterSetName='Insecure', Mandatory, Position=2)]
@@ -79,8 +85,10 @@ function Remove-DnsTxtDomainOffensive {
 
     Write-Verbose "Removing $RecordName with value $TxtValue on Domain Offensive"
     $uri = "https://www.do.de/api/letsencrypt?token=$DomOffTokenInsecure&domain=$RecordName&action=delete"
-    $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic
-    
+    try {
+        $response = Invoke-RestMethod -Method Get -Uri $uri @script:UseBasic -EA Stop
+    } catch { throw }
+
     if (!$response.success) {
         throw "Failed to remove Domain Offensive DNS record; Result=$($response)"
     }
@@ -102,11 +110,15 @@ function Remove-DnsTxtDomainOffensive {
         The fully qualified name of the TXT record to be removed.
 
     .EXAMPLE
-        Remove-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' '' $secureString
-        or
-        Remove-DnsTxtDomainOffensive '_acme-challenge.site1.example.com' '' '1md6xRcUCTrB58kbpwAH'
+        $secToken = Read-Host -Prompt "Token" -AsSecureString
+        PS C:\>Remove-DnsTxtDomainOffensive '_acme-challenge.example.com' 'txt-value' $secToken
 
-        Remove the given TXT record from the account associated with the given token.
+        Removes the specified TXT record with the specified value using a secure token.
+
+    .EXAMPLE
+        Remove-DnsTxtDomainOffensive '_acme-challenge.example.com' 'txt-value' 'token-value'
+
+        Removes the specified TXT record with the specified value using a standard string token.
 
     .LINK
         https://www.do.de/wiki/LetsEncrypt_-_Entwickler
@@ -118,7 +130,7 @@ function Save-DnsTxtDomainOffensive {
     param(
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
-    )    
+    )
 
     <#
     .SYNOPSIS


### PR DESCRIPTION
Thanks for your work. Thought I share my DNS Plugin with you that I use for my hoster [Domain Offensive](https://www.do.de/). Hope I didn't oversee anything but if so, feel free to modify it.

# How To Use the Domain Offensive DNS Plugin

This plugin works against the [Domain Offensive](https://www.do.de/) DNS provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.

## Setup

We need to retrieve an secret API token for the account that will be used to update DNS records. Further information can ba found at [the (german) developer docs.](https://www.do.de/wiki/LetsEncrypt_-_Entwickler).

## Using the Plugin

Your personal API token is specified using the `DomOffToken` or `DomOffTokenInsecure` parameter.


### Windows and/or PS 6.2+ only (secure string)
```powershell
$pArgs = @{
    DomOffToken = $secureString
}
New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
```


### Any OS (default string)
```powershell
$pArgs = @{
    DomOffTokenInsecure = '1md6xRcUCTrB58kbpwAH'
}
New-PACertificate example.com -DnsPlugin DomainOffensive -PluginArgs $pArgs
```
