### PR TITLE
Small change to powershell example in Azure DNS plugin README

### DIFF
--- a/Posh-ACME/DnsPlugins/Azure-Readme.md
+++ b/Posh-ACME/DnsPlugins/Azure-Readme.md
@@ -174,7 +174,7 @@ Here's how to get the token for the context you are currently logged in with usi
 
 ```powershell
 $ctx = Get-AzContext
-$token = ($ctx.TokenCache.ReadItems() | ?{ $_.TenantId -eq $ctx_az.Subscription.TenantId -and $_.Resource -eq "https://management.core.windows.net/" } |
+$token = ($ctx.TokenCache.ReadItems() | ?{ $_.TenantId -eq $ctx.Subscription.TenantId -and $_.Resource -eq "https://management.core.windows.net/" } |
     Select -First 1).AccessToken
 ```
 

--- a/Posh-ACME/DnsPlugins/Azure-Readme.md
+++ b/Posh-ACME/DnsPlugins/Azure-Readme.md
@@ -174,7 +174,7 @@ Here's how to get the token for the context you are currently logged in with usi
 
 ```powershell
 $ctx = Get-AzContext
-$token = ($ctx.TokenCache.ReadItems() | ?{ $_.TenantId -eq $ctx.Subscription.TenantId } |
+$token = ($ctx.TokenCache.ReadItems() | ?{ $_.TenantId -eq $ctx_az.Subscription.TenantId -and $_.Resource -eq "https://management.core.windows.net/" } |
     Select -First 1).AccessToken
 ```
 


### PR DESCRIPTION
Hi,

I've made small change to powershell example in Azure DNS plugin README - [(Optional) Using An Existing Access Token section](https://github.com/rmbolger/Posh-ACME/blob/master/Posh-ACME/DnsPlugins/Azure-Readme.md#optional-using-an-existing-access-token).

I've tried to use code sample
```powershell
$token = ($ctx.TokenCache.ReadItems() | ?{ $_.TenantId -eq $ctx.Subscription.TenantId } |
    Select -First 1).AccessToken
```
but I've encountered next issue:
```
The provided access token has missing or incorrect audience claim. Expected: https://management.core.windows.net/
At C:\Users\......\Documents\WindowsPowerShell\Modules\Posh-ACME\3.13.0\DnsPlugins\Azure.ps1:346 char:9
+         throw "The provided access token has missing or incorrect aud ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (The provided ac...re.windows.net/:String) [], RuntimeException
    + FullyQualifiedErrorId : The provided access token has missing or incorrect audience claim. Expected: https://management.core.windows.net/
```

Fixed code sample that provided in this PR was successfully tested.
And it conforms to note from README:

> To get a token for the MSI when running in a VM, Azure Function or App Service - please refer to the following documentation. Remember to pass in the correct resource uri: https://management.core.windows.net/