### PR TITLE
Add External Account Binding support

### DIFF
--- a/Posh-ACME/Private/New-Jws.ps1
+++ b/Posh-ACME/Private/New-Jws.ps1
@@ -103,6 +103,7 @@ function New-Jws {
         # create the signature
         $HashAlgo = [Security.Cryptography.HashAlgorithmName]::SHA256
         $PaddingType = [Security.Cryptography.RSASignaturePadding]::Pkcs1
+        Write-Debug "Signing message using $($Header.alg)"
         $SignedBytes = $Key.SignData($MessageBytes, $HashAlgo, $PaddingType)
     }
     elseif ($Key -and $Key -is [Security.Cryptography.ECDsa]) {
@@ -124,6 +125,7 @@ function New-Jws {
         }
 
         # create the signature
+        Write-Debug "Signing message using $($Header.alg)"
         $SignedBytes = $Key.SignData($MessageBytes, $HashAlgo)
     }
     else {
@@ -138,6 +140,7 @@ function New-Jws {
         }
 
         # create the signature
+        Write-Debug "Signing message using $($Header.alg)"
         $SignedBytes = $HMAC.ComputeHash($MessageBytes)
     }
 

--- a/Posh-ACME/Private/New-Jws.ps1
+++ b/Posh-ACME/Private/New-Jws.ps1
@@ -134,7 +134,7 @@ function New-Jws {
         # Make sure the header 'alg' matches the hmac type.
         if (($Header.alg -notin 'HS256','HS384','HS512') -or
             ($Header.alg -eq 'HS256' -and $HMAC.HashSize -ne 256) -or
-            ($Header.alg -eq 'HS384' -and $HMAC.HashSize -ne 382) -or
+            ($Header.alg -eq 'HS384' -and $HMAC.HashSize -ne 384) -or
             ($Header.alg -eq 'HS512' -and $HMAC.HashSize -ne 512)) {
             throw "Supplied HMAC object (HashSize $($HMAC.HashSize) does not match 'alg' ($($Header.alg)) in the supplied header or alg is not supported."
         }

--- a/Posh-ACME/Private/New-Jws.ps1
+++ b/Posh-ACME/Private/New-Jws.ps1
@@ -1,15 +1,18 @@
 function New-Jws {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Asymmetric')]
     [OutputType('System.String')]
     param(
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName='Asymmetric', Position=0)]
         [Security.Cryptography.AsymmetricAlgorithm]$Key,
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName='HMAC', Position=0)]
+        [Security.Cryptography.HMAC]$HMAC,
+        [Parameter(Mandatory, Position=1)]
         [hashtable]$Header,
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, Position=2)]
         [AllowEmptyString()]
         [string]$PayloadJson,
         [switch]$Compact,
+        [Parameter(ParameterSetName='Asymmetric')]
         [switch]$NoHeaderValidation
     )
 
@@ -21,63 +24,64 @@ function New-Jws {
     # cater to making JWS messages for the ACME v2 protocol.
     # https://tools.ietf.org/html/rfc8555
 
-    # validate the key type
-    if ($Key -is [Security.Cryptography.RSA]) {
-        $IsRSA = $true
+    if ('Asymmetric' -eq $PSCmdlet.ParameterSetName) {
 
-        # validate the key size
-        # LE supports 2048-4096
-        # Windows claims to support 8-bit increments (mod 128)
-        if ($Key.KeySize -lt 2048 -or $Key.KeySize -gt 4096 -or ($Key.KeySize % 128) -ne 0) {
-            throw "Unsupported RSA key size. Must be 2048-4096 in 8 bit increments."
-        }
+        # validate the key type
+        if ($Key -is [Security.Cryptography.RSA]) {
 
-        # make sure we have a private key to sign with
-        if ($Key.PublicOnly) {
-            throw "Supplied Key has no private key portion."
-        }
-
-    } elseif ($Key -is [Security.Cryptography.ECDsa]) {
-        $IsRSA = $false
-
-        # validate the curve size which is exposed via KeySize
-        if ($Key.KeySize -ne 256 -and $Key.KeySize -ne 384) {
-            throw "Unsupported EC curve. Must be P-256 or P-384"
-        }
-
-        # make sure we have a private key to sign with
-        # since there's no PublicOnly property, we have to fake it by trying to export
-        # the private parameters and catching the error
-        try { $Key.ExportParameters($true) | Out-Null }
-        catch { throw "Supplied Key has no private key portion." }
-
-    } else {
-        throw "Unsupported Key type. Must be RSA or ECDsa"
-    }
-
-    if (-not $NoHeaderValidation) {
-        # validate the header
-        if ('alg' -notin $Header.Keys -or $Header.alg -notin 'RS256','ES256','ES384') {
-            throw "Missing or invalid 'alg' in supplied Header"
-        }
-        if (!('jwk' -in $Header.Keys -xor 'kid' -in $Header.Keys)) {
-            if ('jwk' -in $Header.Keys) {
-                throw "Conflicting key entries. Both 'jwk' and 'kid' found in supplied Header"
-            } else {
-                throw "Missing key entries. Neither 'jwk' or 'kid' found in supplied Header"
+            # validate the key size
+            # LE supports 2048-4096
+            # Windows claims to support 8-bit increments (mod 128)
+            if ($Key.KeySize -lt 2048 -or $Key.KeySize -gt 4096 -or ($Key.KeySize % 128) -ne 0) {
+                throw "Unsupported RSA key size. Must be 2048-4096 in 8 bit increments."
             }
+
+            # make sure we have a private key to sign with
+            if ($Key.PublicOnly) {
+                throw "Supplied Key has no private key portion."
+            }
+
+        } elseif ($Key -is [Security.Cryptography.ECDsa]) {
+
+            # validate the curve size which is exposed via KeySize
+            if ($Key.KeySize -ne 256 -and $Key.KeySize -ne 384) {
+                throw "Unsupported EC curve. Must be P-256 or P-384"
+            }
+
+            # make sure we have a private key to sign with
+            # since there's no PublicOnly property, we have to fake it by trying to export
+            # the private parameters and catching the error
+            try { $Key.ExportParameters($true) | Out-Null }
+            catch { throw "Supplied Key has no private key portion." }
+
+        } else {
+            throw "Unsupported Key type. Must be RSA or ECDsa"
         }
-        if ('jwk' -in $Header.Keys -and [string]::IsNullOrWhiteSpace($Header.jwk)) {
-            throw "Empty 'jwk' in supplied Header."
-        }
-        if ('kid' -in $Header.Keys -and [string]::IsNullOrWhiteSpace($Header.kid)) {
-            throw "Empty 'kid' in supplied Header."
-        }
-        if ('nonce' -notin $Header.Keys -or [string]::IsNullOrWhiteSpace($Header.nonce)) {
-            throw "Missing or empty 'nonce' in supplied Header."
-        }
-        if ('url' -notin $Header.Keys -or [string]::IsNullOrWhiteSpace($Header.url)) {
-            throw "Missing or empty 'url' in supplied Header."
+
+        if (-not $NoHeaderValidation) {
+            # validate the header
+            if ('alg' -notin $Header.Keys -or $Header.alg -notin 'RS256','ES256','ES384') {
+                throw "Missing or invalid 'alg' in supplied Header"
+            }
+            if (!('jwk' -in $Header.Keys -xor 'kid' -in $Header.Keys)) {
+                if ('jwk' -in $Header.Keys) {
+                    throw "Conflicting key entries. Both 'jwk' and 'kid' found in supplied Header"
+                } else {
+                    throw "Missing key entries. Neither 'jwk' or 'kid' found in supplied Header"
+                }
+            }
+            if ('jwk' -in $Header.Keys -and [string]::IsNullOrWhiteSpace($Header.jwk)) {
+                throw "Empty 'jwk' in supplied Header."
+            }
+            if ('kid' -in $Header.Keys -and [string]::IsNullOrWhiteSpace($Header.kid)) {
+                throw "Empty 'kid' in supplied Header."
+            }
+            if ('nonce' -notin $Header.Keys -or [string]::IsNullOrWhiteSpace($Header.nonce)) {
+                throw "Missing or empty 'nonce' in supplied Header."
+            }
+            if ('url' -notin $Header.Keys -or [string]::IsNullOrWhiteSpace($Header.url)) {
+                throw "Missing or empty 'url' in supplied Header."
+            }
         }
     }
 
@@ -89,7 +93,7 @@ function New-Jws {
     $Message = "$HeaderB64.$PayloadB64"
     $MessageBytes = [Text.Encoding]::ASCII.GetBytes($Message)
 
-    if ($IsRSA) {
+    if ($Key -and $Key -is [Security.Cryptography.RSA]) {
         # Make sure header 'alg' matches key type. All RSA keys are currently
         # restricted to RS256 regardless of key size.
         if ($Header.alg -ne 'RS256') {
@@ -100,7 +104,8 @@ function New-Jws {
         $HashAlgo = [Security.Cryptography.HashAlgorithmName]::SHA256
         $PaddingType = [Security.Cryptography.RSASignaturePadding]::Pkcs1
         $SignedBytes = $Key.SignData($MessageBytes, $HashAlgo, $PaddingType)
-    } else {
+    }
+    elseif ($Key -and $Key -is [Security.Cryptography.ECDsa]) {
         # Make sure header 'alg' matches key type. EC keys depend on the curve
         # ES256 = P-256 and SHA256 hash
         # ES384 = P-384 and SHA384 hash
@@ -120,6 +125,20 @@ function New-Jws {
 
         # create the signature
         $SignedBytes = $Key.SignData($MessageBytes, $HashAlgo)
+    }
+    else {
+        # we must be using the passed in HMAC
+
+        # Make sure the header 'alg' matches the hmac type.
+        if (($Header.alg -notin 'HS256','HS384','HS512') -or
+            ($Header.alg -eq 'HS256' -and $HMAC.HashSize -ne 256) -or
+            ($Header.alg -eq 'HS384' -and $HMAC.HashSize -ne 382) -or
+            ($Header.alg -eq 'HS512' -and $HMAC.HashSize -ne 512)) {
+            throw "Supplied HMAC object (HashSize $($HMAC.HashSize) does not match 'alg' ($($Header.alg)) in the supplied header or alg is not supported."
+        }
+
+        # create the signature
+        $SignedBytes = $HMAC.ComputeHash($MessageBytes)
     }
 
     # now put everything together into the final JWS format

--- a/Posh-ACME/Public/New-PAAccount.ps1
+++ b/Posh-ACME/Public/New-PAAccount.ps1
@@ -192,6 +192,15 @@ function New-PAAccount {
     .PARAMETER Force
         If specified, confirmation prompts that may have been generated will be skipped.
 
+    .PARAMETER ExtAcctKID
+        The external account key identifier supplied by the CA. This is required for ACME CAs that require external account binding.
+
+    .PARAMETER ExtAcctHMACKey
+        The external account HMAC key supplied by the CA and encoded as Base64Url. This is required for ACME CAs that require external account binding.
+
+    .PARAMETER ExtAcctAlgorithm
+        The HMAC algorithm to use. Defaults to 'HS256'.
+
     .PARAMETER ExtraParams
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ An [ACME v2 (RFC 8555)](https://tools.ietf.org/html/rfc8555) client implemented 
 - No elevated Windows privileges required *(unless using -Install switch)*
 - Cross platform PowerShell Core support! [(FAQ)](https://github.com/rmbolger/Posh-ACME/wiki/Frequently-Asked-Questions-(FAQ)#does-posh-acme-work-cross-platform-on-powershell-core)
 - Manual HTTP challenge support ([Guide](https://github.com/rmbolger/Posh-ACME/wiki/%28Advanced%29-Manual-HTTP-Challenge-Validation))
+- External Account Binding support for CAs that require it.
 
 # Install
 

--- a/Tests/New-Jws.Tests.ps1
+++ b/Tests/New-Jws.Tests.ps1
@@ -238,7 +238,7 @@ Describe "New-Jws" {
                 { $jws.signature | ConvertFrom-Base64Url -AsByteArray } | Should -Not -Throw
             }
             It "'signature' is correct" {
-                $jws.signature | Should -BeExactly '9XcxZ0lM4bMYmOo_efT8t4t1zg-tjktyUDHzVxTMmTs'
+                $jws.signature | Should -BeExactly 'aL4olvukpK93jKQdehHblFD5tN3-2SQV8NS4Uwa-Zj4'
             }
 
         }


### PR DESCRIPTION
This change addresses #258 and adds additional parameters to `New-PAAccount` that support the external account binding feature described in [RFC 8555 section 7.3.4](https://tools.ietf.org/html/rfc8555#section-7.3.4).

- `-ExtAccountKID` accepts a string value for the key identifier provided by the CA
- `-ExtAccountHMACKey` accepts a string value provided by the CA that represents a Base64Url encoded HMAC key.
- `-ExtAccountAlgorithm` accepts a string value from the set `HS256`, `HS384`,`HS512` which indicates the algorithm to use for creating the MAC from the key. The default value is HS256.

The internal `New-Jws` function was modified to support HMAC keys for JWS generation.

The new parameters in `New-PAAccount` were not also exposed in `New-PACertificate`. Users must explicitly create their ACME account with external binding prior to running `New-PACertificate`.

`New-PAAccount` also now recognizes when an ACME server requires external account binding and provides a better error message to the end user if they haven't supplied the required parameters.