### PR TITLE
PluginArgs for Submit-Renewal -AllOrders & -AllAccounts

### DIFF
--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -112,10 +112,10 @@ function Submit-Renewal {
                     # If new PluginArgs were specified use them
                     if ($PluginArgs) {
                         # recurse to renew these orders
-                        $orders | Submit-Renewal -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -PluginArgs $PluginArgs
+                        $orders | Submit-Renewal -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -NoSkipManualDns:$NoSkipManualDns.IsPresent -PluginArgs $PluginArgs
                     } else {
                         # recurse to renew these orders
-                        $orders | Submit-Renewal -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent
+                        $orders | Submit-Renewal -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -NoSkipManualDns:$NoSkipManualDns.IsPresent
                     }
                 } else {
                     Write-Verbose "No renewable orders found for account $($script:Acct.id)."
@@ -138,10 +138,10 @@ function Submit-Renewal {
                     # If new PluginArgs were specified use them
                     if ($PluginArgs) {
                         # recurse to renew all orders on it
-                        Submit-Renewal -AllOrders -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -PluginArgs $PluginArgs
+                        Submit-Renewal -AllOrders -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -NoSkipManualDns:$NoSkipManualDns.IsPresent -PluginArgs $PluginArgs
                     } else {
                         # recurse to renew all orders on it
-                        Submit-Renewal -AllOrders -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent
+                        Submit-Renewal -AllOrders -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -NoSkipManualDns:$NoSkipManualDns.IsPresent
                     }
                 }
 

--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -109,8 +109,14 @@ function Submit-Renewal {
                 }
 
                 if ($orders.Count -gt 0) {
-                    # recurse to renew these orders
-                    $orders | Submit-Renewal -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent
+                    # If new PluginArgs were specified use them
+                    if ($PluginArgs) {
+                        # recurse to renew these orders
+                        $orders | Submit-Renewal -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -PluginArgs $PluginArgs
+                    } else {
+                        # recurse to renew these orders
+                        $orders | Submit-Renewal -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent
+                    }
                 } else {
                     Write-Verbose "No renewable orders found for account $($script:Acct.id)."
                 }
@@ -129,9 +135,14 @@ function Submit-Renewal {
                 foreach ($acct in $accounts) {
                     # set it as current
                     $acct | Set-PAAccount
-
-                    # recurse to renew all orders on it
-                    Submit-Renewal -AllOrders -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent
+                    # If new PluginArgs were specified use them
+                    if ($PluginArgs) {
+                        # recurse to renew all orders on it
+                        Submit-Renewal -AllOrders -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent -PluginArgs $PluginArgs
+                    } else {
+                        # recurse to renew all orders on it
+                        Submit-Renewal -AllOrders -NewKey:$NewKey.IsPresent -Force:$Force.IsPresent
+                    }
                 }
 
                 # restore the old current account


### PR DESCRIPTION
Currently the parameter "PluginArgs" in Submit-Renewal only works with ParameterSet 'Specific'.
This change modifies 'AllOrders' and 'AllAccounts to use the PluginArgs if present.