### PR TITLE
Add preferred chain support

### DIFF
--- a/Posh-ACME/Private/Get-AlternateLinks.ps1
+++ b/Posh-ACME/Private/Get-AlternateLinks.ps1
@@ -1,0 +1,31 @@
+function Get-AlternateLinks {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0)]
+        [object]$Headers    # gotta be generic since editions have different types
+    )
+
+    # Desktop Header: System.Collections.Generic.Dictionary<string,string>
+    # Core Header   : System.Collections.Generic.Dictionary<string,IEnumerable<string>>
+
+    $reAltLink = '<(?<uri>\S+)>;rel="alternate"'
+
+    if ($Headers -and $Headers.ContainsKey('Link')) {
+        # Regardless of how the link headers are formatted in the response, Desktop
+        # edition will concatenate multiple values with a comma. But Core edition
+        # will return each one in a string array. So we're going to split each string
+        # on a comma to normalize the output.
+        $links = $response.Headers['Link'] | ForEach-Object {
+            $_.Split(',') | ForEach-Object { $_ }
+        }
+        Write-Debug "links has $($links.Count) entries"
+
+        # now find and return the URIs for only the rel="alternate" ones
+        $links | ForEach-Object {
+            if ($_ -match $reAltLink) {
+                $matches['uri']
+            }
+        }
+    }
+
+}

--- a/Posh-ACME/Private/Get-ChainIssuers.ps1
+++ b/Posh-ACME/Private/Get-ChainIssuers.ps1
@@ -6,9 +6,8 @@ function Get-ChainIssuers {
         [string]$OrderFolder
     )
 
-    # Go through the list of chainX.cer files and build a hashtable
-    # where the keys are the Issuer CN value from each cert in the
-    # chain and the value is the path to the file it's in.
+    # Go through the list of chainX.cer files and parse the Issuer CN value
+    # from each cert in the chain then return it and its associated file path.
 
     $files = Get-ChildItem (Join-Path $OrderFolder 'chain*.cer') -Exclude 'chain.cer'
     $issuers = foreach ($f in $files) {

--- a/Posh-ACME/Private/Get-ChainIssuers.ps1
+++ b/Posh-ACME/Private/Get-ChainIssuers.ps1
@@ -1,0 +1,42 @@
+function Get-ChainIssuers {
+    [OutputType([hashtable])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$OrderFolder
+    )
+
+    # Go through the list of chainX.cer files and build a hashtable
+    # where the keys are the Issuer CN value from each cert in the
+    # chain and the value is the path to the file it's in.
+
+    $files = Get-ChildItem (Join-Path $OrderFolder 'chain*.cer') -Exclude 'chain.cer'
+    $issuers = foreach ($f in $files) {
+
+        $filePath = $f.FullName
+        $lines = Get-Content $f
+
+        $iBegin = 0
+        $inCert = $false
+        for ($i=0; $i -lt $lines.Count; $i++) {
+            if ('-----BEGIN CERTIFICATE-----' -eq $lines[$i].Trim()) {
+                $iBegin = $i
+                $inCert = $true
+                continue
+            }
+            if ($inCert -and '-----END CERTIFICATE-----' -eq $lines[$i].Trim()) {
+                $certString = $lines[$iBegin..$i] -join [String]::Empty
+                $cert = Import-Pem -InputString $certString
+                $issuerCN = $cert.IssuerDN.GetValueList([Org.BouncyCastle.Asn1.X509.X509Name]::CN)
+                Write-Debug "Found issuer, $issuerCN, in $filePath"
+                [pscustomobject]@{
+                    issuer = $issuerCN
+                    filePath = $filePath
+                }
+                continue
+            }
+        }
+    }
+
+    return $issuers
+}

--- a/Posh-ACME/Private/Import-Pem.ps1
+++ b/Posh-ACME/Private/Import-Pem.ps1
@@ -97,7 +97,7 @@ function Import-Pem {
             $privSpec = [Org.BouncyCastle.Security.PrivateKeyFactory]::CreateKey($privInfo)
             $pubKey = $pKey.GetPublicKey()
 
-            if ($pubKey -ne $null) {
+            if ($null -ne $pubKey) {
                 $pubInfo = New-Object Org.BouncyCastle.Asn1.X509.SubjectPublicKeyInfo($algId,$pubKey.GetBytes())
                 $pubSpec = [Org.BouncyCastle.Security.PublicKeyFactory]::CreateKey($pubInfo)
             } else {

--- a/Posh-ACME/Private/Import-Pem.ps1
+++ b/Posh-ACME/Private/Import-Pem.ps1
@@ -73,7 +73,7 @@ function Import-Pem {
                 $rsa.Prime1, $rsa.Prime2, $rsa.Exponent1, $rsa.Exponent2,
                 $rsa.Coefficient)
 
-        # check fo EC keys
+        # check for EC keys
         } elseif ($seq[0] -eq 1 -or
                   ($seq[0] -eq 0 -and $seq[1].Count -eq 2 -and
                    $seq[1][0] -eq [Org.BouncyCastle.Asn1.X9.X9ObjectIdentifiers]::IdECPublicKey) ) {

--- a/Posh-ACME/Private/Invoke-ACME.ps1
+++ b/Posh-ACME/Private/Invoke-ACME.ps1
@@ -11,8 +11,7 @@ function Invoke-ACME {
         [Parameter(ParameterSetName='RawKey',Mandatory,Position=2)]
         [ValidateScript({Test-ValidKey $_ -ThrowOnFail})]
         [Security.Cryptography.AsymmetricAlgorithm]$Key,
-        [switch]$NoRetry,
-        [string]$OutFile
+        [switch]$NoRetry
     )
 
     # make sure we have a server configured
@@ -54,9 +53,6 @@ function Invoke-ACME {
             UserAgent = $script:USER_AGENT
             Headers = $script:COMMON_HEADERS
             ErrorAction = 'Stop'
-        }
-        if (-not [String]::IsNullOrWhiteSpace($OutFile)) {
-            $iwrSplat.OutFile = $OutFile
         }
 
         $response = Invoke-WebRequest @iwrSplat @script:UseBasic
@@ -184,9 +180,6 @@ function Invoke-ACME {
 
     .PARAMETER NoRetry
         If specified, don't retry on bad nonce errors. Occasionally, the nonce provided in an ACME message will be rejected. By default, this function requests a new nonce once and tries to send the message again before giving up.
-
-    .PARAMETER OutFile
-        Specifies the output file for which this function saves the response body. Enter a path and file name. If you omit the path, the default is the current location.
 
     .EXAMPLE
         $acct = Get-PAAccount

--- a/Posh-ACME/Private/Split-PemChain.ps1
+++ b/Posh-ACME/Private/Split-PemChain.ps1
@@ -1,17 +1,23 @@
 function Split-PemChain {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='FromFile')]
     param(
-        [Parameter(Mandatory,Position=0)]
-        [string]$ChainFile
+        [Parameter(ParameterSetName='FromFile',Mandatory,Position=0)]
+        [string]$ChainFile,
+        [Parameter(ParameterSetName='FromBytes',Mandatory,Position=0)]
+        [byte[]]$ChainBytes
     )
+
+    if ('FromFile' -eq $PSCmdlet.ParameterSetName) {
+        # resolve relative path
+        $ChainFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ChainFile)
+        $chainLines = Get-Content $ChainFile
+    } else {
+        # encode the bytes and split on the newlines
+        $chainLines = [Text.Encoding]::ASCII.GetString($ChainBytes).Split("`n")
+    }
 
     $PEM_BEGIN = '-----BEGIN *'
     $PEM_END   = '-----END *'
-
-    # resolve relative path
-    $ChainFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ChainFile)
-
-    $chainLines = Get-Content $ChainFile
 
     for ($i=0; $i -lt $chainLines.Count; $i++) {
         if ($chainLines[$i] -like $PEM_BEGIN) {

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -33,7 +33,8 @@ function New-PACertificate {
         [switch]$Install,
         [switch]$Force,
         [int]$DNSSleep=120,
-        [int]$ValidationTimeout=60
+        [int]$ValidationTimeout=60,
+        [string]$PreferredChain
     )
 
     # Make sure we have a server set. But don't override the current
@@ -134,6 +135,13 @@ function New-PACertificate {
             if ([String]::IsNullOrWhiteSpace($orderParams.FriendlyName)) {
                 $orderParams.FriendlyName = $Domain[0]
             }
+        }
+
+        # add new or old preferred chain
+        if ('PreferredChain' -in $PSBoundParameters.Keys) {
+            $orderParams.PreferredChain = $PreferredChain
+        } elseif ($oldOrder.PreferredChain) {
+            $orderParams.PreferredChain = $oldOrder.PreferredChain
         }
 
         # and force a new order
@@ -328,6 +336,9 @@ function New-PACertificate {
 
     .PARAMETER ValidationTimeout
         Number of seconds to wait for the ACME server to validate the challenges after asking it to do so. Default is 60. If the timeout is exceeded, an error will be thrown.
+
+    .PARAMETER PreferredChain
+        If the CA offers multiple certificate chains, prefer the chain with an issuer matching this Subject Common Name. If no match, the default offered chain will be used.
 
     .EXAMPLE
         New-PACertificate site1.example.com -AcceptTOS

--- a/Posh-ACME/Public/Set-PAOrder.ps1
+++ b/Posh-ACME/Public/Set-PAOrder.ps1
@@ -146,7 +146,11 @@ function Set-PAOrder {
 
             if ('PreferredChain' -in $psbKeys -and $PreferredChain -ne $order.PreferredChain) {
                 Write-Verbose "Setting PreferredChain to $PreferredChain"
-                $order.PreferredChain = $PreferredChain
+                if ('PreferredChain' -notin $order.PSObject.Properties.Name) {
+                    $order | Add-Member -MemberType NoteProperty -Name 'PreferredChain' -Value $PreferredChain
+                } else {
+                    $order.PreferredChain = $PreferredChain
+                }
                 $saveChanges = $true
                 $rewritePfx = $true
                 $rewriteCer = $true


### PR DESCRIPTION
This change adds a `-PreferredChain` parameter to `New-PACertificate`, `New-PAOrder`, and `Set-PAOrder` which mimics the functionality [recently introduced](https://github.com/certbot/certbot/blob/master/certbot/CHANGELOG.md#160---2020-07-07) into certbot.

For ACME CAs that offer multiple CA chains via "alternate" link headers, this parameter allows the user to choose which chain to use on a per order/cert basis. Just like certbot, the parameter accepts the Issuer Common Name of any cert in the chain. The first chain with a cert that matches "wins" and all of the resulting cert files are built with that chain. If there are no matches, the default (first) chain is used.

Using `Set-PAOrder -PreferredChain` also allows you regen the cert files with a different chain without needing to get a new cert.