### PR TITLE
Allow authorization objects without the expires property set

### DIFF
--- a/Posh-ACME/Public/Get-PAAuthorizations.ps1
+++ b/Posh-ACME/Public/Get-PAAuthorizations.ps1
@@ -54,9 +54,6 @@ function Get-PAAuthorizations {
             $auth.PSObject.TypeNames.Insert(0,'PoshACME.PAAuthorization')
             Write-Debug "Response: $($auth | ConvertTo-Json)"
 
-            # fix any dates that may have been parsed by PSCore's JSON serializer
-            $auth.expires = Repair-ISODate $auth.expires
-
             # Workaround non-compliant ACME servers such as Nexus CM that don't include
             # the status field on challenge objects. Just copy the auth's status to
             # each challenge.
@@ -69,6 +66,14 @@ function Get-PAAuthorizations {
             }
             if ($nonCompliantServer) {
                 Write-Warning "ACME server returned non-compliant challenge objects with no status. Please report this to your ACME server vendor."
+            }
+
+            # According to RFC 8555 7.1.4 the expires property is only REQUIRED when the property status is "valid".
+            # It's OPTIONAL for any other status and some CA's will not return it.
+            # Only repair the timestamp if it actually exists
+            if([bool]($auth.PSobject.Properties.name -match "expires")) {
+                # fix any dates that may have been parsed by PSCore's JSON serializer
+                $auth.expires = Repair-ISODate $auth.expires
             }
 
             # add "nice to have" members to the auth object

--- a/Posh-ACME/Public/Get-PAAuthorizations.ps1
+++ b/Posh-ACME/Public/Get-PAAuthorizations.ps1
@@ -71,7 +71,7 @@ function Get-PAAuthorizations {
             # According to RFC 8555 7.1.4 the expires property is only REQUIRED when the property status is "valid".
             # It's OPTIONAL for any other status and some CA's will not return it.
             # Only repair the timestamp if it actually exists
-            if([bool]($auth.PSobject.Properties.name -match "expires")) {
+            if ('expires' -in $auth.PSObject.Properties.Name) {
                 # fix any dates that may have been parsed by PSCore's JSON serializer
                 $auth.expires = Repair-ISODate $auth.expires
             }


### PR DESCRIPTION
Posh-ACME will currently fail if a CA does not return expires time in the authorization object. RFC 8555 7.1.4 does not require the expire time to be set unless the status property is set to "valid". For all other statuses the timestamp is optional. 

An example of an RFC 8555 compliant CA returning auth objects without the expiration is Buypass (https://api.buypass.com/acme/directory and https://api.test4.buypass.no/acme/directory). 

This change fixes it by ignoring the expires property if it does not exist instead of stopping with an exception message. 