### PR TITLE
Fix Submit-Renewal -AllOrders so it no longer skips invalid or pending orders

### DIFF
--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -52,7 +52,7 @@ function Submit-Renewal {
                     return
                 }
 
-                # skip orders with no DNS plugin (likely because they were created using custom processes or HTTP validation)
+                # skip orders with no plugin (likely because they were created using custom processes)
                 if ($null -eq $order.Plugin) {
                     Write-Warning "Skipping renewal for order $($order.MainDomain) due to null plugin."
                     return
@@ -100,13 +100,8 @@ function Submit-Renewal {
 
             'AllOrders' {
 
-                # get the list of all completed orders which should have a non-null RenewAfter property
-                $orders = @(Get-PAOrder -List -Refresh | Where-Object { $null -ne $_.RenewAfter })
-
-                # remove the ones that aren't ready for renewal unless -Force was used
-                if (!$Force) {
-                    $orders = @($orders | Where-Object { (Get-DateTimeOffsetNow) -ge ([DateTimeOffset]::Parse($_.RenewAfter)) })
-                }
+                # get all existing orders on this account
+                $orders = @(Get-PAOrder -List -Refresh)
 
                 if ($orders.Count -gt 0) {
 
@@ -124,7 +119,7 @@ function Submit-Renewal {
                     $orders | Submit-Renewal @renewParams
 
                 } else {
-                    Write-Verbose "No renewable orders found for account $($script:Acct.id)."
+                    Write-Verbose "No orders found for account $($script:Acct.id)."
                 }
 
                 break


### PR DESCRIPTION
`Submit-Renewal` when used with the `-AllOrders` parameter does not currently behave the same as when used with the current or a specific order. Most notably, invalid orders such as those that were previously attempted and failed are skipped. This is undesirable in an automated renewal setting where a temporary problem may have caused a validation failure.

This change removes the existing decision making logic from the AllOrders code path and lets it pass through to the specific order code path so things work consistently. A side effect of this change is that verbose output will now output lines for each skipped order.