### PR TITLE
Compatibility updates for RFC2136 plugin

### DIFF
--- a/Posh-ACME/Plugins/RFC2136-Readme.md
+++ b/Posh-ACME/Plugins/RFC2136-Readme.md
@@ -21,6 +21,8 @@ When using a TSIG key, you will typically have 3 values; a key name, a key type 
 
 Due to the inexplicable lack of good native DNS libraries within PowerShell/.NET, this plugin relies on the `nsupdate` utility which is part of the ISC BIND distribution. Most modern Linux distributions will have this installed by default, but double check to be sure. **On Windows, you will need to download and install the utility.** Go to the [ISC BIND Downloads](https://www.isc.org/download/) page and download the current stable version for Windows. You don't actually need to run the installer. It is sufficient to simply unzip the archive and either add that folder to your `PATH` environment variable or specify the full path to `nsupdate.exe` in the plugin arguments. *(Adding the folder to your PATH also gives you easy access to the `dig` utility which many DNS admins prefer over nslookup)*
 
+> **_NOTE:_** Some users have reported needing to install Visual C++ Redistributable libraries in order for the unzip-and-run method to work. Many systems will already have these installed. But if not, among the files unzipped should be a `vcredist_x64.exe` installer you can use. You can test by running `nsupdate -V` to check the version.
+
 ## Using the Plugin
 
 When using unauthenticated updates, the only required parameter is `DDNSNameserver` which is the IP or hostname of the authoritative DNS server that will accept dynamic updates for the zone your TXT record lives in. You may also provide `DDNSPort` if your server is not listening on the standard port 53.
@@ -28,6 +30,8 @@ When using unauthenticated updates, the only required parameter is `DDNSNameserv
 When using TSIG authenticated updates, in addition to the previous parameters you must also supply `DDNSKeyName`, `DDNSKeyType`, and one of two methods to provide the key value. The `DDNSKeyValue` parameter is a SecureString object which can only be used from Windows or any OS with PowerShell 6.2 or later. The other option is `DDNSKeyValueInsecure` which is a standard String.
 
 If the `nsupdate` utility is not in your PATH environment variable, you must also supply the full path to it using the `DDNSExePath` parameter.
+
+There is an optional `DDNSZone` parameter which allows you to specify the zone(s) the records will be added to. But this shouldn't normally be necessary. See [issue #307](https://github.com/rmbolger/Posh-ACME/issues/307) for more info.
 
 Here are a few examples using different combinations of parameters.
 

--- a/Posh-ACME/Plugins/RFC2136.ps1
+++ b/Posh-ACME/Plugins/RFC2136.ps1
@@ -264,10 +264,15 @@ function Send-DynamicTXTUpdate {
 
     try {
         $answerLines = $input | & $NSUpdatePath 2>&1
+        $exitCode = $LASTEXITCODE
     } catch { throw }
 
-    if ($true -notin ($answerLines | ForEach-Object { $_ -like '* status: NOERROR,*' })) {
-        $answerLines | ForEach-Object { Write-Verbose $_ }
-        throw "Unexpected output from nsupdate command. Use -Verbose for details."
+    if ($exitCode -ne 0) {
+        Write-Verbose "nsupdate output:`n$($answerLines -join "`n")"
+        throw "nsupdate returned non-zero exit code which indicates failure. Check -Verbose output for details."
+    } else {
+        # write the nsupdate output to Debug just in case
+        Write-Debug "nsupdate output:`n$($answerLines -join "`n")"
     }
+
 }


### PR DESCRIPTION
This change modifies how the plugin determines a successful nsupdate by checking the exit code rather than trying to parse the output. It also adds an optional `DDNSZone` parameter which adds an explicit zone entry to the update request so that nsupdate doesn't need to make an SOA query to determine the zone. This appears to be necessary in some environments where the DNS server doesn't properly respond to TSIG authenticated SOA queries. Both of these are discussed in more detail in issue #307.