### PR TITLE
DNS Plugin for Infomaniak.com

### DIFF
--- a/Posh-ACME/Plugins/Infomaniak-Readme.md
+++ b/Posh-ACME/Plugins/Infomaniak-Readme.md
@@ -1,0 +1,28 @@
+# How To Use the Infomaniak DNS Plugin
+
+This plugin works against the [Infomaniak](https://www.infomaniak.com) DNS provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.
+
+## Setup
+
+You will need to generate an API Token if you haven't already done so. Go to [Manage API tokens](https://manager.infomaniak.com/v3/0/api/dashboard) after logging in to the [Management Console](https://manager.infomaniak.com). Create a new token with the scope `Domain`. Set the expiration time to your preference. Make a note of the token value as you'll need it later and won't be able to retrieve it after this point.
+
+Note: If the token gets invalidated before a renewal is submitted, a new token has to be created and the order has to be updated.
+
+## Using the Plugin
+
+You will need to provide the API Token as a SecureString value to `InfomaniakToken` or a standard string value to `InfomaniakTokenInsecure`. The SecureString version can only be used from Windows or any OS running PowerShell 6.2 or later.
+
+### Windows or PS 6.2+
+
+```powershell
+$token = Read-Host "Infomaniak Token" -AsSecureString
+$pArgs = @{InfomaniakToken=$token}
+New-PACertificate example.com -Plugin Infomaniak -PluginArgs $pArgs
+```
+
+### Any OS
+
+```powershell
+$pArgs = @{InfomaniakTokenInsecure='xxxxxxxxxxxxxxxxxxxxxxxxx'}
+New-PACertificate example.com -Plugin Infomaniak -PluginArgs $pArgs
+```

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -70,6 +70,9 @@ Function Add-DnsTxt {
             {
                 Write-Verbose "Record $RecordName added with value $TxtValue."
             }
+            {
+                throw "Record $RecordName with value $TxtValue could not be added."
+            }
         } catch { throw }
     }
 
@@ -150,6 +153,10 @@ Function Remove-DnsTxt {
             if($response.result -eq 'success')
             {
                 Write-Verbose "Record $RecordName deleted."
+            }
+            else
+            {
+                throw "Record $RecordName could not be deleted."
             }
         } catch { throw }
     } else {

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -47,8 +47,8 @@ Function Add-DnsTxt {
     # check for a matching record
     $rec = $recs.data | Where-Object {
         $_.type -eq 'TXT' -and
-        $_.source -eq $recShort -and
-        $_.target -eq $TxtValue
+        $_.source_idn -eq $RecordName -and
+        $_.target_idn -eq $TxtValue
     }
 
     if ($rec) {

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -216,6 +216,8 @@ Function Find-InfomaniakZone {
         [hashtable]$RestParameters
     )
 
+    $apiRoot = 'https://api.infomaniak.com'
+
     # setup a module variable to cache the record to zone mapping
     # so it's quicker to find later
     if (!$script:InfomaniakRecordZones) { $script:InfomaniakRecordZones = @{} }

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -226,10 +226,7 @@ Function Find-InfomaniakZone {
     # - sub1.sub2.example.com
     # - sub2.example.com
     # - example.com
-
-    # remove _acme-challenge. from requested RecordName to get the zone
-    $zone = $RecordName.Split('.',2)[1];
-    $zoneTest = $zone;
+    $zoneTest = $RecordName;
     while($zoneTest.Contains('.'))
     {
         Write-Debug "Checking $zoneTest"
@@ -251,6 +248,8 @@ Function Find-InfomaniakZone {
         $zoneTest = $zoneTest.Split('.',2)[1]
     }
 
+    # remove _acme-challenge. from requested zone
+    $zone = $RecordName.Split('.',2)[1]
     Write-Debug "Zone $zone does not exist ..."
     return $null
 }

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -226,7 +226,10 @@ Function Find-InfomaniakZone {
     # - sub1.sub2.example.com
     # - sub2.example.com
     # - example.com
-    $zoneTest = $RecordName;
+
+    # remove _acme-challenge. from requested RecordName to get the zone
+    $zone = $RecordName.Split('.',2)[1];
+    $zoneTest = $zone;
     while($zoneTest.Contains('.'))
     {
         Write-Debug "Checking $zoneTest"
@@ -248,8 +251,6 @@ Function Find-InfomaniakZone {
         $zoneTest = $zoneTest.Split('.',2)[1]
     }
 
-    # remove _acme-challenge. from requested zone
-    $zone = $RecordName.Split('.',2)[1]
     Write-Debug "Zone $zone does not exist ..."
     return $null
 }

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -1,0 +1,255 @@
+function Get-CurrentPluginType { 'dns-01' }
+
+Function Add-DnsTxt {
+    [CmdletBinding(DefaultParameterSetName='Secure')]
+    param(
+        [Parameter(Mandatory,Position = 0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position = 1)]
+        [string]$TxtValue,
+        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [securestring]$InfomaniakToken,
+        [Parameter(ParameterSetName='Insecure',Mandatory,Position=2)]
+        [string]$InfomaniakTokenInsecure,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $apiRoot = 'https://api.infomaniak.com'
+
+    # un-secure the password so we can add it to the auth header
+    if ('Secure' -eq $PSCmdlet.ParameterSetName) {
+        $InfomaniakTokenInsecure = (New-Object PSCredential "user",$InfomaniakToken).GetNetworkCredential().Password
+    }
+    $restParams = @{
+        Headers = @{
+            Authorization = "Bearer $InfomaniakTokenInsecure"
+            Accept = 'application/json'
+        }
+        ContentType = 'application/json'
+    }
+
+    # find matching ZoneID to check, if the records exists already
+    if (-not ($zone = Find-InfomaniakZone $RecordName $restParams)) {
+        throw "Unable to find matching zone for $RecordName"
+    }
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+
+    # Get a list of existing TXT records for this record name
+    try {
+        Write-Verbose "Searching for existing TXT record"
+        $recs = Invoke-RestMethod "$apiRoot/1/domain/$($zone.id)/dns/record" `
+            @restParams @Script:UseBasic -EA Stop
+    } catch { throw }
+
+    # check for a matching record
+    $rec = $recs.data | Where-Object {
+        $_.type -eq 'TXT' -and
+        $_.source -eq $recShort -and
+        $_.target -eq $TxtValue
+    }
+
+    if ($rec) {
+        Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
+    } else {
+        # create request body schema
+        $body = @{
+            type = 'TXT'
+            source = $recShort
+            target = $TxtValue
+            ttl = 600
+        }
+        $json = $body | ConvertTo-Json
+
+        try {
+            $response = Invoke-RestMethod "$apiRoot/1/domain/$($zone.id)/dns/record" -Method Post -Body $json `
+                @restParams @Script:UseBasic -EA Stop
+            if($response.result -eq 'success')
+            {
+                Write-Verbose "Record $RecordName added with value $TxtValue."
+            }
+        } catch { throw }
+    }
+
+    <#
+    .SYNOPSIS
+        Add a DNS TXT record to Infomaniak.
+    .DESCRIPTION
+        Uses the Infomaniak DNS API to add or update a DNS TXT record.
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+    .PARAMETER TxtValue
+        The value of the TXT record.
+    .PARAMETER InfomaniakToken
+        The API token for your Infomaniak account. This SecureString version can only be used on Windows or any OS running PowerShell 6.2 or later.
+    .PARAMETER InfomaniakTokenInsecure
+        The API token for your Infomaniak account. This standard String version may be used on any OS.
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    .EXAMPLE
+        Add-DnsTxt '_acme-challenge.example.com' 'txt-value' -InfomaniakTokenInsecure 'xxxxxxxx'
+        Adds or updates the specified TXT record with the specified value.
+    #>
+}
+
+Function Remove-DnsTxt {
+    [CmdletBinding(DefaultParameterSetName='Secure')]
+    param(
+        [Parameter(Mandatory,Position = 0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position = 1)]
+        [string]$TxtValue,
+        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [securestring]$InfomaniakToken,
+        [Parameter(ParameterSetName='Insecure',Mandatory,Position=2)]
+        [string]$InfomaniakTokenInsecure,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $apiRoot = 'https://api.infomaniak.com'
+
+    # un-secure the password so we can add it to the auth header
+    if ('Secure' -eq $PSCmdlet.ParameterSetName) {
+        $InfomaniakTokenInsecure = (New-Object PSCredential "user",$InfomaniakToken).GetNetworkCredential().Password
+    }
+    $restParams = @{
+        Headers = @{
+            Authorization = "Bearer $InfomaniakTokenInsecure"
+            Accept = 'application/json'
+        }
+        ContentType = 'application/json'
+    }
+
+    # find matching ZoneID to check, if the records exists already
+    if (-not ($zone = Find-InfomaniakZone $RecordName $restParams)) {
+        throw "Unable to find matching zone for $RecordName"
+    }
+
+    # Get a list of existing TXT records for this record name
+    try {
+        Write-Verbose "Searching for existing TXT record"
+        $recs = Invoke-RestMethod "$apiRoot/1/domain/$($zone.id)/dns/record" `
+            @restParams @Script:UseBasic -EA Stop
+    } catch { throw }
+
+    # check for a matching record
+    $rec = $recs.data | Where-Object {
+        $_.type -eq 'TXT' -and
+        $_.source_idn -eq $RecordName -and
+        $_.target_idn -eq $TxtValue
+    }
+
+    if ($rec) {
+        # delete record
+        try {
+            $response = Invoke-RestMethod "$apiRoot/1/domain/$($zone.id)/dns/record/$($rec.id)" -Method Delete `
+                @restParams @Script:UseBasic -EA Stop
+            if($response.result -eq 'success')
+            {
+                Write-Verbose "Record $RecordName deleted."
+            }
+        } catch { throw }
+    } else {
+        Write-Debug "Could not find record $RecordName to delete. Nothing to do."
+    }
+
+    <#
+    .SYNOPSIS
+        Remove a DNS TXT record from Infomaniak.
+    .DESCRIPTION
+        Uses the Infomaniak DNS API to remove DNS TXT record.
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+    .PARAMETER TxtValue
+        The value of the TXT record.
+    .PARAMETER InfomaniakToken
+        The API token for your Infomaniak account. This SecureString version can only be used on Windows or any OS running PowerShell 6.2 or later.
+    .PARAMETER InfomaniakTokenInsecure
+        The API token for your Infomaniak account. This standard String version may be used on any OS.
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    .EXAMPLE
+        Remove-DnsTxt '_acme-challenge.example.com' 'txt-value' -InfomaniakTokenInsecure 'xxxxxxxx'
+        Removes the specified TXT record with the specified value.
+    #>
+}
+
+function Save-DnsTxt {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+    <#
+    .SYNOPSIS
+        Not required.
+    .DESCRIPTION
+        This provider does not require calling this function to commit changes to DNS records.
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    #>
+}
+
+############################
+# Helper Functions
+############################
+
+# API Docs: https://api.infomaniak.com/doc
+
+Function Find-InfomaniakZone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position=0)]
+        [string]$RecordName,
+        [Parameter(Mandatory, Position=1)]
+        [hashtable]$RestParameters
+    )
+
+    # setup a module variable to cache the record to zone mapping
+    # so it's quicker to find later
+    if (!$script:InfomaniakRecordZones) { $script:InfomaniakRecordZones = @{} }
+
+    # check for the record in the cache
+    if ($script:InfomaniakRecordZones.ContainsKey($RecordName)) {
+        Write-Debug "Result from Cache $($script:InfomaniakRecordZones.$RecordName.name)"
+        return $script:InfomaniakRecordZones.$RecordName
+    }
+
+    # We need to find the closest/deepest
+    # sub-zone that would hold the record rather than just adding it to the apex. So for something
+    # like _acme-challenge.site1.sub1.sub2.example.com, we'd look for zone matches in the following
+    # order:
+    # - site1.sub1.sub2.example.com
+    # - sub1.sub2.example.com
+    # - sub2.example.com
+    # - example.com
+    $zoneTest = $RecordName;
+    while($zoneTest.Contains('.'))
+    {
+        Write-Debug "Checking $zoneTest"
+        try {
+            $response = Invoke-RestMethod -Uri "$apiRoot/1/product?service_name=domain&customer_name=$zoneTest" `
+                @RestParameters @Script:UseBasic -EA Stop
+            $zoneId = $response.data.id
+            if($zoneId)
+            {
+                Write-Debug "Zone $zoneTest found. Zone ID is $zoneId"
+                $script:InfomaniakRecordZones.$RecordName = @{
+                    name = $zoneTest
+                    id = $zoneId
+                }
+                return $script:InfomaniakRecordZones.$RecordName;
+            }
+        } catch { throw }
+        # remove one sub site
+        $zoneTest = $zoneTest.Split('.',2)[1]
+    }
+
+    # remove _acme-challenge. from requested zone
+    $zone = $RecordName.Split('.',2)[1]
+    Write-Debug "Zone $zone does not exist ..."
+    return $null
+}

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -70,6 +70,7 @@ Function Add-DnsTxt {
             {
                 Write-Verbose "Record $RecordName added with value $TxtValue."
             }
+            else
             {
                 throw "Record $RecordName with value $TxtValue could not be added."
             }
@@ -255,8 +256,6 @@ Function Find-InfomaniakZone {
         $zoneTest = $zoneTest.Split('.',2)[1]
     }
 
-    # remove _acme-challenge. from requested zone
-    $zone = $RecordName.Split('.',2)[1]
     Write-Debug "Zone $zone does not exist ..."
     return $null
 }

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -1,4 +1,4 @@
-function Get-CurrentPluginType { 'dns-01' }
+Function Get-CurrentPluginType { 'dns-01' }
 
 Function Add-DnsTxt {
     [CmdletBinding(DefaultParameterSetName='Secure')]
@@ -222,7 +222,7 @@ Function Find-InfomaniakZone {
 
     # check for the record in the cache
     if ($script:InfomaniakRecordZones.ContainsKey($RecordName)) {
-        Write-Debug "Result from Cache $($script:InfomaniakRecordZones.$RecordName.name)"
+        Write-Debug "Result from Cache $($script:InfomaniakRecordZones.$RecordName.name) (ID $($script:InfomaniakRecordZones.$RecordName.id))"
         return $script:InfomaniakRecordZones.$RecordName
     }
 
@@ -256,6 +256,6 @@ Function Find-InfomaniakZone {
         $zoneTest = $zoneTest.Split('.',2)[1]
     }
 
-    Write-Debug "Zone $zone does not exist ..."
+    Write-Debug "Zone for $RecordName does not exist ..."
     return $null
 }


### PR DESCRIPTION
Hi @rmbloger. 
First of all: Thank you so much for this ACME client.

I added a DNS Plugin for the hoster Infomaniak from Switzerland. 

I did use the plugin on two Windows Servers and a Windows Desktop which all worked well.
I tested:
- example.com
- *.example.com
- sub.example.com
- sub2.sub1.example.com

I've got one question. Is there a way to tell the user if something failed? e.g., the zone hasn't been found? Refer to line [69](https://github.com/Sundypha/Posh-ACME/blob/dns1-infomaniak-plugin/Posh-ACME/Plugins/Infomaniak.ps1#L69) and line [150](https://github.com/Sundypha/Posh-ACME/blob/dns1-infomaniak-plugin/Posh-ACME/Plugins/Infomaniak.ps1#L150) where I could fail gracefully.

Awaiting your review and feedback!

Best
Simon