### PR TITLE
Add support for http acme-dns endpoint

### DIFF
--- a/Posh-ACME/Plugins/AcmeDns.ps1
+++ b/Posh-ACME/Plugins/AcmeDns.ps1
@@ -92,6 +92,9 @@ function Add-DnsTxt {
     .PARAMETER ACMEServer
         The FQDN of the acme-dns server instance.
 
+    .PARAMETER HTTP
+        Use HTTP when connecting to the ACME-DNS endpoint.
+
     .PARAMETER ACMEAllowFrom
         A list of networks in CIDR notation that the acme-dns server should allow updates from. If not specified, the acme-dns server will not block any updates based on IP address.
 

--- a/Posh-ACME/Plugins/AcmeDns.ps1
+++ b/Posh-ACME/Plugins/AcmeDns.ps1
@@ -9,6 +9,7 @@ function Add-DnsTxt {
         [string]$TxtValue,
         [Parameter(Mandatory,Position=2)]
         [string]$ACMEServer,
+        [switch]$HTTP,
         [string[]]$ACMEAllowFrom,
         [hashtable]$ACMERegistration,
         [Parameter(ValueFromRemainingArguments)]
@@ -60,10 +61,17 @@ function Add-DnsTxt {
     # create the update body
     $updateBody = @{subdomain=$regVals[0];txt=$TxtValue} | ConvertTo-Json -Compress
 
+    # Use http if explicitly requested
+    $protocol = "https"
+    if ($HTTP) {
+        $protocol = "http"
+    }
+
+
     # send the update
     try {
         Write-Verbose "Updating $($regVals[3]) with $TxtValue"
-        $response = Invoke-RestMethod "https://$ACMEServer/update" -Method Post `
+        $response = Invoke-RestMethod "$($protocol)://$ACMEServer/update" -Method Post `
             -Headers $authHead -Body $updateBody @script:UseBasic
         Write-Debug ($response | ConvertTo-Json)
     } catch { throw }
@@ -181,7 +189,8 @@ function New-AcmeDnsRegistration {
         [Parameter(Mandatory,Position=0)]
         [string]$ACMEServer,
         [Parameter(Position=1)]
-        [string[]]$ACMEAllowFrom
+        [string[]]$ACMEAllowFrom,
+        [switch]$HTTP
     )
 
     # build the registration body
@@ -191,10 +200,16 @@ function New-AcmeDnsRegistration {
         $regBody = '{}'
     }
 
+    # Use http if explicitly requested
+    $protocol = "https"
+    if ($HTTP) {
+        $protocol = "http"
+    }
+
     # do the registration
     try {
         Write-Verbose "Registering new subdomain on $ACMEServer"
-        $reg = Invoke-RestMethod "https://$ACMEServer/register" -Method POST -Body $regBody `
+        $reg = Invoke-RestMethod "$($protocol)://$ACMEServer/register" -Method POST -Body $regBody `
             -ContentType 'application/json' @script:UseBasic
         Write-Debug ($reg | ConvertTo-Json)
     } catch { throw }


### PR DESCRIPTION
Hi @rmbolger

Thanks so much for this great tool.

I had a niche need for http support with the acme-dns plugin. I hope it's not a problem to add it to the plugin.

I tested it using `Publish-Challenge`  and it passed.

Sample json to pass though

```
$reg = @{
    '_acme-challenge.www.example.com' = @(
        'ec6ec1f4-836e-462e-b577-b2f4e04d7291'
        'aeb00c77-852b-465e-9b27-984bc6cb12f5'
        'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
        'ec6ec1f4-836e-462e-b577-b2f4e04d7291.acmedns.example.com'
    )
}

$pArgs = @{
    ACMEServer = 'acmedns.example.com'
    ACMERegistration = $reg
    HTTP = $true
}
```