### PR TITLE
add support for acme-dns that uses http

### DIFF
--- a/Posh-ACME/Plugins/AcmeDns-Readme.md
+++ b/Posh-ACME/Plugins/AcmeDns-Readme.md
@@ -10,7 +10,7 @@ Once you have your instance running, it needs to be accessible via HTTPS to your
 
 ## Using the Plugin
 
-The only required parameter for the plugin is `ACMEServer` which is the hostname of the acme-dns instance you are using. If you have a setup that is different than the default acme-dns config, you might want to use the `ACMEUri` parameter instead tht allows you to provide the full URI to the server including protocol, port and path.
+The only required parameter for the plugin is `ACMEServer` which is the hostname of the acme-dns instance you are using. If you have a setup that is different than the default acme-dns config, if you customized your acme-dns deployment you might want to use the `ACMEUri` parameter instead that allows you to provide the full URI to the server including http/s, port and custom path.
 
 There is also an optional `ACMEAllowFrom` parameter which takes an array of strings with networks specified in CIDR notation. If included, these networks will be the only ones that can send TXT record updates to the server for the registrations that get created as part of the certificate request. In some environments, it may make more sense to control network access via standard firewalls.
 
@@ -27,7 +27,7 @@ _acme-challenge.example.com -> xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.auth.acme-dn
 Press any key to continue.:
 ```
 
-For each CNAME in the list, you need to create the associated record on your DNS server before continuing. Assuming the records get created properly, the process should complete succesfully. Future renewals will complete without additional prompting as long as no new names are added to the cert.
+For each CNAME in the list, you need to create the associated record on your DNS server before continuing. Assuming the records get created properly, the process should complete successfully. Future renewals will complete without additional prompting as long as no new names are added to the cert.
 
 ## (Advanced) Pre-registration and CNAME creation
 

--- a/Posh-ACME/Plugins/AcmeDns-Readme.md
+++ b/Posh-ACME/Plugins/AcmeDns-Readme.md
@@ -10,7 +10,7 @@ Once you have your instance running, it needs to be accessible via HTTPS to your
 
 ## Using the Plugin
 
-The only required parameter for the plugin is `ACMEServer` which is the hostname of the acme-dns instance you are using. If you have a setup that is different than the default acme-dns config, if you customized your acme-dns deployment you might want to use the `ACMEUri` parameter instead that allows you to provide the full URI to the server including http/s, port and custom path.
+If your acme-dns instance is using the default configuration running with TLS on port 443, the only required parameter for the plugin is `ACMEServer` which is the hostname of your instance. If you are not using TLS, using an alternate port, or require additional uri path segments, you will need to specify the full URI using `ACMEUri` instead.
 
 There is also an optional `ACMEAllowFrom` parameter which takes an array of strings with networks specified in CIDR notation. If included, these networks will be the only ones that can send TXT record updates to the server for the registrations that get created as part of the certificate request. In some environments, it may make more sense to control network access via standard firewalls.
 

--- a/Posh-ACME/Plugins/AcmeDns-Readme.md
+++ b/Posh-ACME/Plugins/AcmeDns-Readme.md
@@ -10,7 +10,9 @@ Once you have your instance running, it needs to be accessible via HTTPS to your
 
 ## Using the Plugin
 
-The only required parameter for the plugin is `ACMEServer` which is the hostname of the acme-dns instance you are using. There is also an optional `ACMEAllowFrom` parameter which takes an array of strings with networks specified in CIDR notation. If included, these networks will be the only ones that can send TXT record updates to the server for the registrations that get created as part of the certificate request. In some environments, it may make more sense to control network access via standard firewalls.
+The only required parameter for the plugin is `ACMEServer` which is the hostname of the acme-dns instance you are using. If you have a setup that is different than the default acme-dns config, you might want to use the `ACMEUri` parameter instead tht allows you to provide the full URI to the server including protocol, port and path.
+
+There is also an optional `ACMEAllowFrom` parameter which takes an array of strings with networks specified in CIDR notation. If included, these networks will be the only ones that can send TXT record updates to the server for the registrations that get created as part of the certificate request. In some environments, it may make more sense to control network access via standard firewalls.
 
 This plugin is ultimately using CNAME aliases for DNS challenges under the hood. The first time you use it, you will be prompted to create the necessary CNAME records for each new name included in a cert.
 


### PR DESCRIPTION
Hi @rmbolger

Thanks so much for this great tool.

I had a niche need for http support with the acme-dns plugin. I hope it's not a problem to add it to the plugin.

I tested it using `Publish-Challenge`  and it passed.

Sample json to pass though

```
$reg = @{
    '_acme-challenge.www.example.com' = @(
        'ec6ec1f4-836e-462e-b577-b2f4e04d7291'
        'aeb00c77-852b-465e-9b27-984bc6cb12f5'
        'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
        'ec6ec1f4-836e-462e-b577-b2f4e04d7291.acmedns.example.com'
    )
}

$pArgs = @{
    ACMEServer = 'acmedns.example.com'
    ACMERegistration = $reg
    HTTP = $true
}
```

Please excuse me if I made mistakes, I'm a rookie in git and open source in general (this is my very first PR).