### PR TITLE
Correct Windows PowerShell reference in first line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Posh-ACME
 
-An [ACME (RFC 8555)](https://tools.ietf.org/html/rfc8555) client implemented as a Windows PowerShell module that enables you to generate publicly trusted SSL/TLS certificates from an ACME capable certificate authority such as [Let's Encrypt](https://letsencrypt.org/).
+An [ACME (RFC 8555)](https://tools.ietf.org/html/rfc8555) client implemented as a [PowerShell module](#requirements-and-platform-support) that enables you to generate publicly trusted SSL/TLS certificates from an ACME capable certificate authority such as [Let's Encrypt](https://letsencrypt.org/).
 
 # Notable Features
 


### PR DESCRIPTION
This changes the reference to Windows PowerShell in the first line to "PowerShell" with a link to the platform requirements as PowerShell 7 (and PSCore) are now supported as well.