### PR TITLE
Added New-PAAuthorization

### DIFF
--- a/Posh-ACME/Posh-ACME.psd1
+++ b/Posh-ACME/Posh-ACME.psd1
@@ -36,6 +36,7 @@ FunctionsToExport = @(
     'New-PAAccount'
     'New-PACertificate'
     'New-PAOrder'
+    'New-PreAuthorization'
     'Publish-Challenge'
     'Remove-PAAccount'
     'Remove-PAOrder'

--- a/Posh-ACME/Posh-ACME.psd1
+++ b/Posh-ACME/Posh-ACME.psd1
@@ -36,7 +36,7 @@ FunctionsToExport = @(
     'New-PAAccount'
     'New-PACertificate'
     'New-PAOrder'
-    'New-PreAuthorization'
+    'New-PAAuthorization'
     'Publish-Challenge'
     'Remove-PAAccount'
     'Remove-PAOrder'

--- a/Posh-ACME/Private/ConvertTo-PAAuthorization.ps1
+++ b/Posh-ACME/Private/ConvertTo-PAAuthorization.ps1
@@ -1,0 +1,72 @@
+function ConvertTo-PAAuthorization {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$ResponseBody,
+        [Parameter(Mandatory,Position=1)]
+        [string]$Location
+    )
+
+    # Most of what a user cares about in an authorization object is the challenge
+    # data. To make processing easier, we're going to flatten the challenge data
+    # so you don't have to loop into a sub-array. This may get unwieldy if too
+    # many additional challenge types are added in the future.
+
+    $auth = $ResponseBody | ConvertFrom-Json
+
+    # inject the type name
+    $auth.PSObject.TypeNames.Insert(0,'PoshACME.PAAuthorization')
+
+    # Workaround non-compliant ACME servers such as Nexus CM that don't include
+    # the status field on challenge objects. Just copy the auth's status to
+    # each challenge.
+    $nonCompliantServer = $false
+    $auth.challenges | ForEach-Object {
+        if ('status' -notin $_.PSObject.Properties.Name) {
+            $nonCompliantServer = $true
+            $_ | Add-Member -MemberType NoteProperty -Name 'status' -Value $auth.status
+        }
+    }
+    if ($nonCompliantServer) {
+        Write-Warning "ACME server returned non-compliant challenge objects with no status. Please report this to your ACME server vendor."
+    }
+
+    # According to RFC 8555 7.1.4 the expires property is only REQUIRED when the property status is "valid".
+    # It's OPTIONAL for any other status and some CA's will not return it.
+    # Only repair the timestamp if it actually exists
+    if ('expires' -in $auth.PSObject.Properties.Name) {
+        # fix any dates that may have been parsed by PSCore's JSON serializer
+        $auth.expires = Repair-ISODate $auth.expires
+    }
+
+    # add "nice to have" members to the auth object
+    # add members that expose the details of the 'dns-01' and 'http-01'
+    # challenge in the root of the object
+    $auth | Add-Member -NotePropertyMembers @{
+        DNSId        = $auth.identifier.value
+        fqdn         = "$(if ($auth.wildcard) {'*.'})$($auth.identifier.value)"
+        location     = $Location
+        DNS01Status  = $null
+        DNS01Url     = $null
+        DNS01Token   = $null
+        HTTP01Status = $null
+        HTTP01Url    = $null
+        HTTP01Token  = $null
+    }
+
+    $dnsChallenge = $auth.challenges | Where-Object { $_.type -eq 'dns-01' }
+    if ($dnsChallenge) {
+        $auth.DNS01Status = $dnsChallenge.status
+        $auth.DNS01Url    = $dnsChallenge.url
+        $auth.DNS01Token  = $dnsChallenge.token
+    }
+
+    $httpChallenge = $auth.challenges | Where-Object { $_.type -eq 'http-01' }
+    if ($httpChallenge) {
+        $auth.HTTP01Status = $httpChallenge.status
+        $auth.HTTP01Url    = $httpChallenge.url
+        $auth.HTTP01Token  = $httpChallenge.token
+    }
+
+    $auth
+}

--- a/Posh-ACME/Public/New-PAAuthorization.ps1
+++ b/Posh-ACME/Public/New-PAAuthorization.ps1
@@ -3,31 +3,28 @@ function New-PAAuthorization {
     [OutputType('PoshACME.PAAuthorization')]
     param(
         [Parameter(Mandatory,Position=0,ValueFromPipeline)]
-        [string]$Domain
+        [string[]]$Domain,
+        [Parameter(Position=1)]
+        [PSTypeName('PoshACME.PAAccount')]$Account
     )
 
     Begin {
-        # Make sure we have an account configured
-        if (-not ($acct = Get-PAAccount)) {
-            try { throw "No ACME account configured. Run Set-PAAccount or New-PAAccount first." }
-            catch { $PSCmdlet.ThrowTerminatingError($_) }
-        }
-
         # Make sure the current server actually supports pre-authorization
         if (-not $script:Dir.newAuthz) {
-            try { throw "The current ACME server does not support pre-authorization." }
+            try { throw "The current ACME server does not support pre-authorization. Use New-PAOrder or New-PACertificate instead." }
             catch { $PSCmdlet.ThrowTerminatingError($_) }
         }
-    }
 
-    Process {
-
-        # build the protected header for the request
-        $header = @{
-            alg   = $acct.alg;
-            kid   = $acct.location;
-            nonce = $script:Dir.nonce;
-            url   = $script:Dir.newAuthz;
+        # Make sure there's a valid account
+        if (-not $Account) {
+            if (-not ($Account = Get-PAAccount)) {
+                try { throw "No Account parameter specified and no current account selected. Try running Set-PAAccount first." }
+                catch { $PSCmdlet.ThrowTerminatingError($_) }
+            }
+        }
+        if ($Account.status -ne 'valid') {
+            try { throw "Account status is $($Account.status)." }
+            catch { $PSCmdlet.ThrowTerminatingError($_) }
         }
 
         # super lazy IPv4 address regex, but we just need to be able to
@@ -42,89 +39,90 @@ function New-PAAuthorization {
         # if the IP address entered is actually valid or not, only that it is
         # parsable as an IP address and should be sent as one rather than a
         # DNS name.
-
-        # build the payload object
-        if ($Domain -match $reIPv4 -or $Domain -like '*:*') {
-            Write-Debug "$Domain identified as IP address. Attempting to parse."
-            $ip = [ipaddress]$Domain
-
-            $payload = @{ identifier = @{type='ip';value=$ip.ToString()} }
-        }
-        else {
-            $payload = @{ identifier = @{type='dns';value=$Domain} }
-        }
-
-        $payloadJson = $payload | ConvertTo-Json -Depth 5 -Compress
-
-        # send the request
-        try {
-            $response = Invoke-ACME $header $payloadJson $acct -EA Stop
-            $auth = $response.Content | ConvertFrom-Json
-        } catch { throw }
-
-        # inject the type name
-        $auth.PSObject.TypeNames.Insert(0,'PoshACME.PAAuthorization')
-
-        # grab the location from the header
-        if ($response.Headers.ContainsKey('Location')) {
-            $location = $response.Headers['Location'] | Select-Object -First 1
-        } else {
-            try { throw 'No Location header found in newAuthz output' }
-            catch { $PSCmdlet.ThrowTerminatingError($_) }
-        }
-
-        # Workaround non-compliant ACME servers such as Nexus CM that don't include
-        # the status field on challenge objects. Just copy the auth's status to
-        # each challenge.
-        $nonCompliantServer = $false
-        $auth.challenges | ForEach-Object {
-            if ('status' -notin $_.PSObject.Properties.Name) {
-                $nonCompliantServer = $true
-                $_ | Add-Member -MemberType NoteProperty -Name 'status' -Value $auth.status
-            }
-        }
-        if ($nonCompliantServer) {
-            Write-Warning "ACME server returned non-compliant challenge objects with no status. Please report this to your ACME server vendor."
-        }
-
-        # According to RFC 8555 7.1.4 the expires property is only REQUIRED when the property status is "valid".
-        # It's OPTIONAL for any other status and some CA's will not return it.
-        # Only repair the timestamp if it actually exists
-        if ('expires' -in $auth.PSObject.Properties.Name) {
-            # fix any dates that may have been parsed by PSCore's JSON serializer
-            $auth.expires = Repair-ISODate $auth.expires
-        }
-
-        # add "nice to have" members to the auth object
-        # add members that expose the details of the 'dns-01' and 'http-01'
-        # challenge in the root of the object
-        $auth | Add-Member -NotePropertyMembers @{
-            DNSId        = $auth.identifier.value
-            fqdn         = "$(if ($auth.wildcard) {'*.'})$($auth.identifier.value)"
-            location     = $location
-            DNS01Status  = $null
-            DNS01Url     = $null
-            DNS01Token   = $null
-            HTTP01Status = $null
-            HTTP01Url    = $null
-            HTTP01Token  = $null
-        }
-
-        $dnsChallenge = $auth.challenges | Where-Object { $_.type -eq 'dns-01' }
-        if ($dnsChallenge) {
-            $auth.DNS01Status = $dnsChallenge.status
-            $auth.DNS01Url    = $dnsChallenge.url
-            $auth.DNS01Token  = $dnsChallenge.token
-        }
-
-        $httpChallenge = $auth.challenges | Where-Object { $_.type -eq 'http-01' }
-        if ($httpChallenge) {
-            $auth.HTTP01Status = $httpChallenge.status
-            $auth.HTTP01Url    = $httpChallenge.url
-            $auth.HTTP01Token  = $httpChallenge.token
-        }
-
-        Write-Output $auth
-
     }
+
+    Process {
+
+        foreach ($name in $Domain) {
+
+            # build the protected header for the request
+            $header = @{
+                alg   = $Account.alg;
+                kid   = $Account.location;
+                nonce = $script:Dir.nonce;
+                url   = $script:Dir.newAuthz;
+            }
+
+            # build the payload object
+            if ($name -match $reIPv4 -or $name -like '*:*') {
+                Write-Debug "$name identified as IP address. Attempting to parse."
+                $ip = [ipaddress]$name
+
+                $payload = @{ identifier = @{type='ip';value=$ip.ToString()} }
+            }
+            else {
+                $payload = @{ identifier = @{type='dns';value=$name} }
+            }
+
+            $payloadJson = $payload | ConvertTo-Json -Depth 5 -Compress
+
+            # send the request
+            try {
+                $response = Invoke-ACME $header $payloadJson $Account -EA Stop
+
+                # grab the location from the header
+                if ($response.Headers.ContainsKey('Location')) {
+                    $location = $response.Headers['Location'] | Select-Object -First 1
+                } else {
+                    throw 'No Location header found in response output'
+                }
+            } catch {
+                Write-Error $_
+                continue
+            }
+
+            ConvertTo-PAAuthorization $response.Content $location
+
+        }
+    }
+
+
+
+
+
+    <#
+    .SYNOPSIS
+        Create a pre-authorization for an ACME identifier.
+
+    .DESCRIPTION
+        Instead of creating an ACME order object and satisfying the associated authorization challenges on demand, users may choose to pre-authorize one or more identifiers in advance. When a user later creates an order with pre-authorized identifiers, it will be immediately ready to finalize.
+
+        NOTE: Not all ACME servers support pre-authorization. The authorizations created this way also expire the same way they do when associated directly with an order.
+
+    .PARAMETER Domain
+        One or more ACME identifiers (usually domain names).
+
+    .PARAMETER Account
+        An existing ACME account object such as the output from Get-PAAccount. If no account is specified, the current account will be used.
+
+    .EXAMPLE
+        $auth = New-PAAuthorization example.com
+
+        Create a new authorization for the specified domain using the current account.
+
+    .EXAMPLE
+        $auths = 'example.com','www.example.com' | New-PAAuthorization -Account (Get-PAAccount 123)
+
+        Create new authorizations for the specified domains via the pipeline and using the specified account.
+
+    .LINK
+        Project: https://github.com/rmbolger/Posh-ACME
+
+    .LINK
+        Get-PAAuthorization
+
+    .LINK
+        New-PAOrder
+
+    #>
 }

--- a/Posh-ACME/Public/New-PAAuthorization.ps1
+++ b/Posh-ACME/Public/New-PAAuthorization.ps1
@@ -1,4 +1,4 @@
-function New-PreAuthorization {
+function New-PAAuthorization {
     [CmdletBinding()]
     [OutputType('PoshACME.PAAuthorization')]
     param(

--- a/Posh-ACME/Public/New-PreAuthorization.ps1
+++ b/Posh-ACME/Public/New-PreAuthorization.ps1
@@ -1,0 +1,122 @@
+function New-PreAuthorization {
+    [CmdletBinding()]
+    [OutputType('PoshACME.PAAuthorization')]
+    param(
+        [Parameter(Mandatory,Position=0,ValueFromPipeline)]
+        [string]$Domain
+    )
+
+    Begin {
+        # Make sure we have an account configured
+        if (-not ($acct = Get-PAAccount)) {
+            try { throw "No ACME account configured. Run Set-PAAccount or New-PAAccount first." }
+            catch { $PSCmdlet.ThrowTerminatingError($_) }
+        }
+
+        # Make sure the current server actually supports pre-authorization
+        if (-not $script:Dir.newAuthz) {
+            try { throw "The current ACME server does not support pre-authorization." }
+            catch { $PSCmdlet.ThrowTerminatingError($_) }
+        }
+    }
+
+    Process {
+
+        # build the protected header for the request
+        $header = @{
+            alg   = $acct.alg;
+            kid   = $acct.location;
+            nonce = $script:Dir.nonce;
+            url   = $script:Dir.newAuthz;
+        }
+
+        # super lazy IPv4 address regex, but we just need to be able to
+        # distinguish from an FQDN
+        $reIPv4 = [regex]'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
+
+        # IP identifiers (RFC8738) are an extension to the original ACME protocol
+        # https://tools.ietf.org/html/rfc8738
+        #
+        # So we have to distinguish between domain FQDNs and IPv4/v6 addresses
+        # and send the appropriate identifier type for each one. We don't care
+        # if the IP address entered is actually valid or not, only that it is
+        # parsable as an IP address and should be sent as one rather than a
+        # DNS name.
+
+        # build the payload object
+        if ($Domain -match $reIPv4 -or $Domain -like '*:*') {
+            Write-Debug "$Domain identified as IP address. Attempting to parse."
+            $ip = [ipaddress]$Domain
+
+            $payload = @{ identifier = @{type='ip';value=$ip.ToString()} }
+        }
+        else {
+            $payload = @{ identifier = @{type='dns';value=$Domain} }
+        }
+
+        $payloadJson = $payload | ConvertTo-Json -Depth 5 -Compress
+
+        # send the request
+        try {
+            $response = Invoke-ACME $header $payloadJson $acct -EA Stop
+            $auth = $response.Content | ConvertFrom-Json
+        } catch { throw }
+
+        # inject the type name
+        $auth.PSObject.TypeNames.Insert(0,'PoshACME.PAAuthorization')
+
+        # Workaround non-compliant ACME servers such as Nexus CM that don't include
+        # the status field on challenge objects. Just copy the auth's status to
+        # each challenge.
+        $nonCompliantServer = $false
+        $auth.challenges | ForEach-Object {
+            if ('status' -notin $_.PSObject.Properties.Name) {
+                $nonCompliantServer = $true
+                $_ | Add-Member -MemberType NoteProperty -Name 'status' -Value $auth.status
+            }
+        }
+        if ($nonCompliantServer) {
+            Write-Warning "ACME server returned non-compliant challenge objects with no status. Please report this to your ACME server vendor."
+        }
+
+        # According to RFC 8555 7.1.4 the expires property is only REQUIRED when the property status is "valid".
+        # It's OPTIONAL for any other status and some CA's will not return it.
+        # Only repair the timestamp if it actually exists
+        if ('expires' -in $auth.PSObject.Properties.Name) {
+            # fix any dates that may have been parsed by PSCore's JSON serializer
+            $auth.expires = Repair-ISODate $auth.expires
+        }
+
+        # add "nice to have" members to the auth object
+        # add members that expose the details of the 'dns-01' and 'http-01'
+        # challenge in the root of the object
+        $auth | Add-Member -NotePropertyMembers @{
+            DNSId        = $auth.identifier.value
+            fqdn         = "$(if ($auth.wildcard) {'*.'})$($auth.identifier.value)"
+            location     = $AuthUrl
+            DNS01Status  = $null
+            DNS01Url     = $null
+            DNS01Token   = $null
+            HTTP01Status = $null
+            HTTP01Url    = $null
+            HTTP01Token  = $null
+        }
+
+        $dnsChallenge = $auth.challenges | Where-Object { $_.type -eq 'dns-01' }
+        if ($dnsChallenge) {
+            $auth.DNS01Status = $dnsChallenge.status
+            $auth.DNS01Url    = $dnsChallenge.url
+            $auth.DNS01Token  = $dnsChallenge.token
+        }
+
+        $httpChallenge = $auth.challenges | Where-Object { $_.type -eq 'http-01' }
+        if ($httpChallenge) {
+            $auth.HTTP01Status = $httpChallenge.status
+            $auth.HTTP01Url    = $httpChallenge.url
+            $auth.HTTP01Token  = $httpChallenge.token
+        }
+
+        Write-Output $auth
+
+    }
+}

--- a/Posh-ACME/Public/New-PreAuthorization.ps1
+++ b/Posh-ACME/Public/New-PreAuthorization.ps1
@@ -65,6 +65,14 @@ function New-PreAuthorization {
         # inject the type name
         $auth.PSObject.TypeNames.Insert(0,'PoshACME.PAAuthorization')
 
+        # grab the location from the header
+        if ($response.Headers.ContainsKey('Location')) {
+            $location = $response.Headers['Location'] | Select-Object -First 1
+        } else {
+            try { throw 'No Location header found in newAuthz output' }
+            catch { $PSCmdlet.ThrowTerminatingError($_) }
+        }
+
         # Workaround non-compliant ACME servers such as Nexus CM that don't include
         # the status field on challenge objects. Just copy the auth's status to
         # each challenge.
@@ -93,7 +101,7 @@ function New-PreAuthorization {
         $auth | Add-Member -NotePropertyMembers @{
             DNSId        = $auth.identifier.value
             fqdn         = "$(if ($auth.wildcard) {'*.'})$($auth.identifier.value)"
-            location     = $AuthUrl
+            location     = $location
             DNS01Status  = $null
             DNS01Url     = $null
             DNS01Token   = $null


### PR DESCRIPTION
Some ACME servers may support [pre-authorization](https://datatracker.ietf.org/doc/html/rfc8555#section-7.4.1) which allows users to create and validate authorization objects outside of the normal order lifecycle.

`New-PAAuthorization` enables users to request new authorization objects for a given set of identifiers. If authorization objects already exist for a given identifier, the ACME server will return the existing object.

Currently, the only public ACME CA that seems to support pre-authorization is BuyPass.