### PR TITLE
Use modern PBES2 for private keys in PFX (fixes #446)

### DIFF
--- a/Posh-ACME/Private/Export-CertPfx.ps1
+++ b/Posh-ACME/Private/Export-CertPfx.ps1
@@ -9,7 +9,8 @@ function Export-CertPfx {
         [string]$OutputFile,
         [string]$ChainFile,
         [string]$FriendlyName,
-        [string]$PfxPass=''
+        [string]$PfxPass='',
+        [switch]$UseModernPfxEncryption
     )
 
     $CertFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($CertFile)
@@ -28,12 +29,29 @@ function Export-CertPfx {
         $FriendlyName = $cert.Subject.GetValueList([Org.BouncyCastle.Asn1.X509.X509Name]::CN)[0]
     }
 
-    # create a new Pkcs12StoreBuilder
-    $storebuilder = New-Object Org.BouncyCastle.Pkcs.Pkcs12StoreBuilder
-    # Certs could be left unencrypted since it's just the public part, but BouncyCastle does not support it - it also does not expose PKCS5 Scheme 2 for certs.
-    $storebuilder.SetCertAlgorithm([Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::PbeWithShaAnd3KeyTripleDesCbc.Id) | Out-Null
-    # Configure the Pkcs12Store to use PKCS5 Scheme 2 for private keys, using AES256CBC and HMAC-SHA256. 
-    $storebuilder.SetKeyAlgorithm([Org.BouncyCastle.Asn1.Nist.NistObjectIdentifiers]::IdAes256Cbc.Id, [Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::IdHmacWithSha256.Id) | Out-Null
+    # create a new Pkcs12Store
+    $storebuilder = [Org.BouncyCastle.Pkcs.Pkcs12StoreBuilder]::new()
+    $storebuilder.SetCertAlgorithm(
+        [Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::PbeWithShaAnd3KeyTripleDesCbc.Id
+    ) | Out-Null
+
+    # The private key algorithm option affects compatibility with various versions
+    # of OpenSSL. The default, "RC2-40-CBC", works with 1.0.x and 1.1.x, but not
+    # 3.x unless additional "legacy" parameters are used. The modern option,
+    # "AES256 with SHA256" is not supported on 1.0.x.
+    if ($UseModernPfxEncryption) {
+        # Use PKCS5 Scheme 2 with AES256CBC and HMAC-SHA256
+        $storebuilder.SetKeyAlgorithm(
+            [Org.BouncyCastle.Asn1.Nist.NistObjectIdentifiers]::IdAes256Cbc.Id,
+            [Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::IdHmacWithSha256.Id
+        ) | Out-Null
+    } else {
+        # Use legacy RC2-40-CBC
+        $storebuilder.SetKeyAlgorithm(
+            [Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::PbewithShaAnd40BitRC2Cbc.Id
+        ) | Out-Null
+    }
+
     $store = $storebuilder.Build()
 
     # add the private key

--- a/Posh-ACME/Private/Export-CertPfx.ps1
+++ b/Posh-ACME/Private/Export-CertPfx.ps1
@@ -28,8 +28,13 @@ function Export-CertPfx {
         $FriendlyName = $cert.Subject.GetValueList([Org.BouncyCastle.Asn1.X509.X509Name]::CN)[0]
     }
 
-    # create a new Pkcs12Store
-    $store = New-Object Org.BouncyCastle.Pkcs.Pkcs12Store
+    # create a new Pkcs12StoreBuilder
+    $storebuilder = New-Object Org.BouncyCastle.Pkcs.Pkcs12StoreBuilder
+    # Certs could be left unencrypted since it's just the public part, but BouncyCastle does not support it - it also does not expose PKCS5 Scheme 2 for certs.
+    $storebuilder.SetCertAlgorithm([Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::PbeWithShaAnd3KeyTripleDesCbc.Id) | Out-Null
+    # Configure the Pkcs12Store to use PKCS5 Scheme 2 for private keys, using AES256CBC and HMAC-SHA256. 
+    $storebuilder.SetKeyAlgorithm([Org.BouncyCastle.Asn1.Nist.NistObjectIdentifiers]::IdAes256Cbc.Id, [Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::IdHmacWithSha256.Id) | Out-Null
+    $store = $storebuilder.Build()
 
     # add the private key
     try {

--- a/Posh-ACME/Private/Export-PACertFiles.ps1
+++ b/Posh-ACME/Private/Export-PACertFiles.ps1
@@ -152,6 +152,9 @@ function Export-PACertFiles {
             FriendlyName = $Order.FriendlyName;
             PfxPass      = $Order.PfxPass;
         }
+        if ($Order.UseModernPfxEncryption) {
+            $pfxParams.UseModernPfxEncryption = $true
+        }
         Export-CertPfx @pfxParams
         $pfxParams.OutputFile = $pfxFullFile
         Export-CertPfx @pfxParams -ChainFile $chainFile

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -37,6 +37,8 @@ function New-PACertificate {
         [ValidateScript({Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail})]
         [securestring]$PfxPassSecure,
         [Parameter(ParameterSetName='FromScratch')]
+        [switch]$UseModernPfxEncryption,
+        [Parameter(ParameterSetName='FromScratch')]
         [ValidateScript({Test-WinOnly -ThrowOnFail})]
         [switch]$Install,
         [switch]$UseSerialValidation,
@@ -150,14 +152,15 @@ function New-PACertificate {
         else {
             # set the defaults based on what was passed in
             $orderParams = @{
-                Domain         = $Domain
-                Name           = $Name
-                KeyLength      = $CertKeyLength
-                OCSPMustStaple = $OCSPMustStaple
-                AlwaysNewKey   = $AlwaysNewKey
-                FriendlyName   = $FriendlyName
-                PfxPass        = $PfxPass
-                Install        = $Install
+                Domain                 = $Domain
+                Name                   = $Name
+                KeyLength              = $CertKeyLength
+                OCSPMustStaple         = $OCSPMustStaple
+                AlwaysNewKey           = $AlwaysNewKey
+                FriendlyName           = $FriendlyName
+                PfxPass                = $PfxPass
+                UseModernPfxEncryption = $UseModernPfxEncryption
+                Install                = $Install
             }
 
             # add values from the old order if they exist and weren't overrridden
@@ -167,6 +170,7 @@ function New-PACertificate {
                     'AlwaysNewKey'
                     'FriendlyName'
                     'PfxPass'
+                    'UseModernPfxEncryption'
                     'Install' ) | ForEach-Object {
 
                     if ($oldOrder.$_ -and $_ -notin $psbKeys) {
@@ -221,6 +225,7 @@ function New-PACertificate {
             'Install'
             'FriendlyName'
             'PfxPass'
+            'UseModernPfxEncryption'
             'Install'
             'DnsSleep'
             'ValidationTimeout'

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -38,6 +38,9 @@ function New-PAOrder {
         [securestring]$PfxPassSecure,
         [Parameter(ParameterSetName='FromScratch')]
         [Parameter(ParameterSetName='ImportKey')]
+        [switch]$UseModernPfxEncryption,
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
         [switch]$Install,
         [switch]$UseSerialValidation,
         [int]$DnsSleep=120,
@@ -290,6 +293,9 @@ function New-PAOrder {
     }
     if ('LifetimeDays' -in $PSBoundParameters.Keys) {
         $order.LifetimeDays = $LifetimeDays
+    }
+    if ('UseModernPfxEncryption' -in $PSBoundParameters.Keys) {
+        $order | Add-Member UseModernPfxEncryption $UseModernPfxEncryption.IsPresent -Force
     }
 
     # add the Name and Folder properties

--- a/Posh-ACME/Public/Set-PAOrder.ps1
+++ b/Posh-ACME/Public/Set-PAOrder.ps1
@@ -37,6 +37,8 @@ function Set-PAOrder {
         [ValidateScript({Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail})]
         [securestring]$PfxPassSecure,
         [Parameter(ParameterSetName='Edit')]
+        [switch]$UseModernPfxEncryption,
+        [Parameter(ParameterSetName='Edit')]
         [switch]$Install,
         [Parameter(ParameterSetName='Edit')]
         [switch]$OCSPMustStaple,
@@ -212,6 +214,15 @@ function Set-PAOrder {
                 Write-Verbose "Setting LifetimeDays to $LifetimeDays"
                 $order.LifetimeDays = $LifetimeDays
                 $saveChanges = $true
+            }
+
+            if ('UseModernPfxEncryption' -in $psbKeys -and
+                (-not $order.UseModernPfxEncryption -or $UseModernPfxEncryption.IsPresent -ne $order.UseModernPfxEncryption)
+            ) {
+                Write-Verbose "Setting UseModernPfxEncryption to $($UseModernPfxEncryption.IsPresent)"
+                $order | Add-Member 'UseModernPfxEncryption' $UseModernPfxEncryption.IsPresent -Force
+                $saveChanges = $true
+                $rewritePfx = $true
             }
 
             if ($saveChanges) {

--- a/Posh-ACME/en-US/Posh-ACME-help.xml
+++ b/Posh-ACME/en-US/Posh-ACME-help.xml
@@ -3042,6 +3042,17 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseModernPfxEncryption</maml:name>
+          <maml:description>
+            <maml:para>If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PACertificate</maml:name>
@@ -3501,6 +3512,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseModernPfxEncryption</maml:name>
+        <maml:description>
+          <maml:para>If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues>
@@ -3833,6 +3856,17 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseModernPfxEncryption</maml:name>
+          <maml:description>
+            <maml:para>If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PAOrder</maml:name>
@@ -4068,6 +4102,17 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseModernPfxEncryption</maml:name>
+          <maml:description>
+            <maml:para>If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
@@ -4490,6 +4535,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseModernPfxEncryption</maml:name>
+        <maml:description>
+          <maml:para>If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -6958,6 +7015,17 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>UseModernPfxEncryption</maml:name>
+          <maml:description>
+            <maml:para>If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -7224,6 +7292,18 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>UseModernPfxEncryption</maml:name>
+        <maml:description>
+          <maml:para>If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />

--- a/docs/Functions/New-PACertificate.md
+++ b/docs/Functions/New-PACertificate.md
@@ -18,8 +18,9 @@ Request a new certificate
 New-PACertificate [-Domain] <String[]> [-Name <String>] [-Contact <String[]>] [-CertKeyLength <String>]
  [-AlwaysNewKey] [-AcceptTOS] [-AccountKeyLength <String>] [-DirectoryUrl <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple]
- [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-Install] [-UseSerialValidation]
- [-Force] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>] [<CommonParameters>]
+ [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
+ [-Install] [-UseSerialValidation] [-Force] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
+ [-PreferredChain <String>] [<CommonParameters>]
 ```
 
 ### FromCSR
@@ -480,6 +481,22 @@ How long in days the certificate should be valid for. NOTE: Many CAs do not supp
 ```yaml
 Type: Int32
 Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseModernPfxEncryption
+
+If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: FromScratch
 Aliases:
 
 Required: False

--- a/docs/Functions/New-PAOrder.md
+++ b/docs/Functions/New-PAOrder.md
@@ -17,18 +17,18 @@ Create a new order on the current ACME account.
 ```powershell
 New-PAOrder [-Domain] <String[]> [[-KeyLength] <String>] [-Name <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
- [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-Install] [-UseSerialValidation]
- [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
+ [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>]
+ [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ImportKey
 ```powershell
 New-PAOrder [-Domain] <String[]> -KeyFile <String> [-Name <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
- [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-Install] [-UseSerialValidation]
- [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
+ [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>]
+ [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### FromCSR
@@ -443,6 +443,22 @@ How long in days the certificate should be valid for. NOTE: Many CAs do not supp
 ```yaml
 Type: Int32
 Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseModernPfxEncryption
+
+If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: FromScratch, ImportKey
 Aliases:
 
 Required: False

--- a/docs/Functions/Set-PAOrder.md
+++ b/docs/Functions/Set-PAOrder.md
@@ -17,9 +17,9 @@ Switch to or modify an order.
 ```powershell
 Set-PAOrder [[-MainDomain] <String>] [-Name <String>] [-NoSwitch] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-NewName <String>]
- [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-Install] [-OCSPMustStaple]
- [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-AlwaysNewKey]
- [-UseSerialValidation] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
+ [-Install] [-OCSPMustStaple] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>]
+ [-AlwaysNewKey] [-UseSerialValidation] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Revoke
@@ -409,6 +409,22 @@ How long in days the certificate should be valid for. This will only affect futu
 
 ```yaml
 Type: Int32
+Parameter Sets: Edit
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseModernPfxEncryption
+
+If specified, PFX files generated from this order will use AES256 with SHA256 for the private key encryption instead of the default which is RC2-40-CBC. This can affect compatibility with some crypto libraries and tools. Most notably, OpenSSL 3.x requires the newer options to avoid using "legacy" mode. But it breaks compatibility with OpenSSL 1.0.x.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: Edit
 Aliases:
 


### PR DESCRIPTION
Fixes #446

This raises security a bit, allows OpenSSL 3.x to read it without legacy mode, and in general is just a good idea.

As for compatibility, it *should* be well supported. OpenSSL, as far as I know, supports it since 1.1.1, and all earlier versions are out of support upstream. Windows also has no issues with it.