### PR TITLE
Fix for NameSilo API change

### DIFF
--- a/Posh-ACME/Plugins/NameSilo.ps1
+++ b/Posh-ACME/Plugins/NameSilo.ps1
@@ -226,7 +226,7 @@ function Find-NameSiloZone {
     if ($response -and $response.namesilo.reply.code -ne 300) {
         throw "Unexpected response from NameSilo API: $($response.namesilo.reply.detail)"
     }
-    $domains = @($response.namesilo.reply.domains.domain)
+    $domains = @($response.namesilo.reply.domains.domain | Select-Object -ExpandProperty "#text")
 
     # find the closest match based on the record name
     $pieces = $RecordName.Split('.')


### PR DESCRIPTION
NameSilo has made an undocumented API change to the listDomains query, it now returns the domain expiry as an xml property.  This filters out the expiry so the domain can be found again.