### PR TITLE
Added Subject parameter to New-PACertificate

### DIFF
--- a/Posh-ACME/Private/New-Csr.ps1
+++ b/Posh-ACME/Private/New-Csr.ps1
@@ -75,7 +75,7 @@ function New-Csr {
 
     # create the subject
     if ($Order.Subject) {
-        $subject = New-Object Org.BouncyCastle.Asn1.X509.X509Name("$($Order.Subject)")
+        $subject = New-Object Org.BouncyCastle.Asn1.X509.X509Name($Order.Subject)
     } else {
         $subject = New-Object Org.BouncyCastle.Asn1.X509.X509Name("CN=$($Order.MainDomain)")
     }

--- a/Posh-ACME/Private/New-Csr.ps1
+++ b/Posh-ACME/Private/New-Csr.ps1
@@ -2,7 +2,7 @@ function New-Csr {
     [CmdletBinding()]
     [OutputType('System.String')]
     param(
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory,Position=0)]
         [PSTypeName('PoshACME.PAOrder')]$Order
     )
 
@@ -22,17 +22,15 @@ function New-Csr {
 
         if ($Order.KeyLength -notlike 'ec-*') {
             $sigAlgo = 'SHA256WITHRSA'
-        }
-        else {
+        } else {
             $keySize = [int]$Order.KeyLength.Substring(3)
             if ($keySize -eq 256) { $sigAlgo = 'SHA256WITHECDSA' }
             elseif ($keySize -eq 384) { $sigAlgo = 'SHA384WITHECDSA' }
             elseif ($keySize -eq 521) { $sigAlgo = 'SHA512WITHECDSA' }
         }
 
-        # Nope, new key needed
-    }
-    else {
+    # Nope, new key needed
+    } else {
 
         Write-Verbose "Creating new private key for the certificate request."
 
@@ -50,12 +48,11 @@ function New-Csr {
             elseif ($keySize -eq 521) { $sigAlgo = 'SHA512WITHECDSA' }
 
             $ecGen = New-Object Org.BouncyCastle.Crypto.Generators.ECKeyPairGenerator
-            $genParam = New-Object Org.BouncyCastle.Crypto.Parameters.ECKeyGenerationParameters -ArgumentList $curveOid, $sRandom
+            $genParam = New-Object Org.BouncyCastle.Crypto.Parameters.ECKeyGenerationParameters -ArgumentList $curveOid,$sRandom
             $ecGen.Init($genParam)
             $keyPair = $ecGen.GenerateKeyPair()
 
-        }
-        else {
+        } else {
 
             # RSA key
             Write-Debug "Creating BC RSA keypair of type $($Order.KeyLength)"
@@ -63,7 +60,7 @@ function New-Csr {
             $sigAlgo = 'SHA256WITHRSA'
 
             $rsaGen = New-Object Org.BouncyCastle.Crypto.Generators.RsaKeyPairGenerator
-            $genParam = New-Object Org.BouncyCastle.Crypto.KeyGenerationParameters -ArgumentList $sRandom, $keySize
+            $genParam = New-Object Org.BouncyCastle.Crypto.KeyGenerationParameters -ArgumentList $sRandom,$keySize
             $rsaGen.Init($genParam)
             $keyPair = $rsaGen.GenerateKeyPair()
 
@@ -77,10 +74,9 @@ function New-Csr {
     # start building the cert request
 
     # create the subject
-    if ($order.Subject) {
+    if ($Order.Subject) {
         $subject = New-Object Org.BouncyCastle.Asn1.X509.X509Name("$($Order.Subject)")
-    }
-    else {
+    } else {
         $subject = New-Object Org.BouncyCastle.Asn1.X509.X509Name("CN=$($Order.MainDomain)")
     }
 
@@ -92,8 +88,7 @@ function New-Csr {
     if ($Order.KeyLength -like 'ec-*') {
         # Only DigitalSignature on ECC certs because KeyEncipherment not supported
         $keyUsage = New-Object Org.BouncyCastle.Asn1.X509.X509Extension($true, (New-Object Org.BouncyCastle.Asn1.DerOctetString(New-Object Org.BouncyCastle.Asn1.X509.KeyUsage([Org.BouncyCastle.Asn1.X509.KeyUsage]::DigitalSignature))))
-    }
-    else {
+    } else {
         # DigitalSignature and KeyEncipherment on RSA certs
         $keyUsage = New-Object Org.BouncyCastle.Asn1.X509.X509Extension($true, (New-Object Org.BouncyCastle.Asn1.DerOctetString(New-Object Org.BouncyCastle.Asn1.X509.KeyUsage([Org.BouncyCastle.Asn1.X509.KeyUsage]::DigitalSignature -bor [Org.BouncyCastle.Asn1.X509.KeyUsage]::KeyEncipherment))))
     }
@@ -114,7 +109,7 @@ function New-Csr {
             Write-Warning "Skipping unexpected identifier type '$($_.type)' with value '$($_.value)'."
         }
     }
-    $sans = New-Object Org.BouncyCastle.Asn1.X509.X509Extension($false, (New-Object Org.BouncyCastle.Asn1.DerOctetString(New-Object Org.BouncyCastle.Asn1.X509.GeneralNames(@(, $genNames)))))
+    $sans = New-Object Org.BouncyCastle.Asn1.X509.X509Extension($false, (New-Object Org.BouncyCastle.Asn1.DerOctetString(New-Object Org.BouncyCastle.Asn1.X509.GeneralNames(@(,$genNames)))))
 
     # add them to a DerSet object
     $extDict.Add([Org.BouncyCastle.Asn1.X509.X509Extensions]::BasicConstraints, $basicConstraints)
@@ -126,16 +121,16 @@ function New-Csr {
     # add OCSP Must Staple if requested
     if ($Order.OCSPMustStaple) {
         Write-Debug "Adding OCSP Must-Staple"
-        $mustStaple = New-Object Org.BouncyCastle.Asn1.X509.X509Extension($false, (New-Object Org.BouncyCastle.Asn1.DerOctetString(@(, [byte[]](0x30, 0x03, 0x02, 0x01, 0x05)))))
+        $mustStaple = New-Object Org.BouncyCastle.Asn1.X509.X509Extension($false, (New-Object Org.BouncyCastle.Asn1.DerOctetString(@(,[byte[]](0x30,0x03,0x02,0x01,0x05)))))
         $extDict.Add((New-Object Org.BouncyCastle.Asn1.DerObjectIdentifier('1.3.6.1.5.5.7.1.24')), $mustStaple)
     }
 
     # build the extensions DerSet
     $extensions = New-Object Org.BouncyCastle.Asn1.X509.X509Extensions($extDict)
-    $extDerSet = New-Object Org.BouncyCastle.Asn1.DerSet(New-Object Org.BouncyCastle.Asn1.Pkcs.AttributePkcs([Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::Pkcs9AtExtensionRequest, (New-Object Org.BouncyCastle.Asn1.DerSet($extensions))))
+    $extDerSet = New-Object Org.BouncyCastle.Asn1.DerSet(New-Object Org.BouncyCastle.Asn1.Pkcs.AttributePkcs([Org.BouncyCastle.Asn1.Pkcs.PkcsObjectIdentifiers]::Pkcs9AtExtensionRequest,(New-Object Org.BouncyCastle.Asn1.DerSet($extensions))))
 
     # create the request object
-    $req = New-Object Org.BouncyCastle.Pkcs.Pkcs10CertificationRequest($sigAlgo, $subject, $keyPair.Public, $extDerSet, $keyPair.Private)
+    $req = New-Object Org.BouncyCastle.Pkcs.Pkcs10CertificationRequest($sigAlgo,$subject,$keyPair.Public,$extDerSet,$keyPair.Private)
 
     # export the csr to a file
     Export-Pem $req $reqFile

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -1,50 +1,52 @@
 function New-PACertificate {
-    [CmdletBinding(DefaultParameterSetName='FromScratch')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText','')]
+    [CmdletBinding(DefaultParameterSetName = 'FromScratch')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')]
     param(
-        [Parameter(ParameterSetName='FromScratch',Mandatory,Position=0)]
+        [Parameter(ParameterSetName = 'FromScratch', Mandatory, Position = 0)]
         [string[]]$Domain,
-        [Parameter(ParameterSetName='FromCSR',Mandatory,Position=0)]
+        [Parameter(ParameterSetName = 'FromCSR', Mandatory, Position = 0)]
         [string]$CSRPath,
-        [ValidateScript({Test-ValidFriendlyName $_ -ThrowOnFail})]
+        [ValidateScript({ Test-ValidFriendlyName $_ -ThrowOnFail })]
         [string]$Name,
         [string[]]$Contact,
-        [Parameter(ParameterSetName='FromScratch')]
-        [ValidateScript({Test-ValidKeyLength $_ -ThrowOnFail})]
-        [string]$CertKeyLength='2048',
-        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName = 'FromScratch')]
+        [ValidateScript({ Test-ValidKeyLength $_ -ThrowOnFail })]
+        [string]$CertKeyLength = '2048',
+        [Parameter(ParameterSetName = 'FromScratch')]
         [switch]$AlwaysNewKey,
         [switch]$AcceptTOS,
-        [ValidateScript({Test-ValidKeyLength $_ -ThrowOnFail})]
-        [string]$AccountKeyLength='ec-256',
-        [ValidateScript({Test-ValidDirUrl $_ -ThrowOnFail})]
+        [ValidateScript({ Test-ValidKeyLength $_ -ThrowOnFail })]
+        [string]$AccountKeyLength = 'ec-256',
+        [ValidateScript({ Test-ValidDirUrl $_ -ThrowOnFail })]
         [Alias('location')]
-        [string]$DirectoryUrl='LE_PROD',
-        [ValidateScript({Test-ValidPlugin $_ -ThrowOnFail})]
+        [string]$DirectoryUrl = 'LE_PROD',
+        [ValidateScript({ Test-ValidPlugin $_ -ThrowOnFail })]
         [Alias('DnsPlugin')]
         [string[]]$Plugin,
         [hashtable]$PluginArgs,
         [ValidateRange(0, 3650)]
         [int]$LifetimeDays,
         [string[]]$DnsAlias,
-        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName = 'FromScratch')]
         [switch]$OCSPMustStaple,
-        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName = 'FromScratch')]
+        [string]$Subject,
+        [Parameter(ParameterSetName = 'FromScratch')]
         [string]$FriendlyName,
-        [Parameter(ParameterSetName='FromScratch')]
-        [string]$PfxPass='poshacme',
-        [Parameter(ParameterSetName='FromScratch')]
-        [ValidateScript({Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail})]
+        [Parameter(ParameterSetName = 'FromScratch')]
+        [string]$PfxPass = 'poshacme',
+        [Parameter(ParameterSetName = 'FromScratch')]
+        [ValidateScript({ Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail })]
         [securestring]$PfxPassSecure,
-        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName = 'FromScratch')]
         [switch]$UseModernPfxEncryption,
-        [Parameter(ParameterSetName='FromScratch')]
-        [ValidateScript({Test-WinOnly -ThrowOnFail})]
+        [Parameter(ParameterSetName = 'FromScratch')]
+        [ValidateScript({ Test-WinOnly -ThrowOnFail })]
         [switch]$Install,
         [switch]$UseSerialValidation,
         [switch]$Force,
-        [int]$DnsSleep=120,
-        [int]$ValidationTimeout=60,
+        [int]$DnsSleep = 120,
+        [int]$ValidationTimeout = 60,
         [string]$PreferredChain
     )
 
@@ -55,7 +57,8 @@ function New-PACertificate {
     # one unless explicitly specified.
     if (-not (Get-PAServer) -or 'DirectoryUrl' -in $psbKeys) {
         Set-PAServer -DirectoryUrl $DirectoryUrl
-    } else {
+    }
+    else {
         # refresh the directory info (which should also get a fresh nonce)
         Set-PAServer
     }
@@ -67,7 +70,7 @@ function New-PACertificate {
     # accounts, create a new one.
     $acct = Get-PAAccount
     $acctListParams = @{
-        List = $true
+        List   = $true
         Status = 'valid'
     }
     if ('Contact' -in $PSBoundParameters.Keys) { $acctListParams.Contact = $Contact }
@@ -78,7 +81,8 @@ function New-PACertificate {
         Write-Verbose "Creating a new $AccountKeyLength account with contact: $($Contact -join ', ')"
         try { $acct = New-PAAccount @PSBoundParameters -EA Stop }
         catch { $PSCmdlet.ThrowTerminatingError($_) }
-    } elseif ($accts.Count -gt 0 -and (-not $acct -or $acct.id -notin $accts.id)) {
+    }
+    elseif ($accts.Count -gt 0 -and (-not $acct -or $acct.id -notin $accts.id)) {
         # we got matches, but there's no current account or the current one doesn't match
         # so set the first match as current
         $acct = $accts[0]
@@ -105,13 +109,13 @@ function New-PACertificate {
         }
 
         # override the existing PfxPass parameter
-        $PfxPass = [pscredential]::new('u',$PfxPassSecure).GetNetworkCredential().Password
+        $PfxPass = [pscredential]::new('u', $PfxPassSecure).GetNetworkCredential().Password
         $PSBoundParameters.PfxPass = $PfxPass
     }
 
     # Generate an appropriate name if one wasn't specified
     if (-not $Name) {
-        $Name = $Domain[0].Replace('*','!')
+        $Name = $Domain[0].Replace('*', '!')
         Write-Verbose "Order name not specified, using '$Name'"
     }
 
@@ -130,14 +134,13 @@ function New-PACertificate {
     $oldOrder = $null
     $SANs = @($Domain | Where-Object { $_ -ne $Domain[0] }) | Sort-Object
     if ($Force -or -not $order -or
-        $order.status -in 'invalid','deactivated' -or
+        $order.status -in 'invalid', 'deactivated' -or
         ($order.status -eq 'valid' -and $order.RenewAfter -and (Get-DateTimeOffsetNow) -ge ([DateTimeOffset]::Parse($order.RenewAfter))) -or
         ($order.status -eq 'pending' -and (Get-DateTimeOffsetNow) -gt ([DateTimeOffset]::Parse($order.expires))) -or
         $CertKeyLength -ne $order.KeyLength -or
         ($SANs -join ',') -ne (($order.SANs | Sort-Object) -join ',') -or
         ($csrDetails -and $csrDetails.Base64Url -ne $order.CSRBase64Url ) -or
-        ($LifetimeDays -and $LifetimeDays -ne $order.LifetimeDays) )
-    {
+        ($LifetimeDays -and $LifetimeDays -ne $order.LifetimeDays) ) {
 
         $oldOrder = $order
 
@@ -146,7 +149,7 @@ function New-PACertificate {
             # most values will be pulled from the CSR
             $orderParams = @{
                 CSRPath = $CSRPath
-                Name = $Name
+                Name    = $Name
             }
         }
         else {
@@ -157,6 +160,7 @@ function New-PACertificate {
                 KeyLength              = $CertKeyLength
                 OCSPMustStaple         = $OCSPMustStaple
                 AlwaysNewKey           = $AlwaysNewKey
+                Subject                = $Subject
                 FriendlyName           = $FriendlyName
                 PfxPass                = $PfxPass
                 UseModernPfxEncryption = $UseModernPfxEncryption
@@ -199,7 +203,8 @@ function New-PACertificate {
 
             if ($_ -in $psbKeys) {
                 $orderParams.$_ = $PSBoundParameters.$_
-            } elseif ($oldOrder -and $oldOrder.$_) {
+            }
+            elseif ($oldOrder -and $oldOrder.$_) {
                 $orderParams.$_ = $oldOrder.$_
             }
         }
@@ -212,7 +217,8 @@ function New-PACertificate {
         Write-Debug "New order params: `n$($orderParams | ConvertTo-Json -Depth 5)"
         $order = New-PAOrder @orderParams -Force
 
-    } else {
+    }
+    else {
         # set the existing order as active and override explicit order properties that
         # don't need to trigger a new order
         Write-Verbose "Using existing order '$($order.Name)' with status $($order.status)"
@@ -223,6 +229,7 @@ function New-PACertificate {
             'PluginArgs'
             'DnsAlias'
             'Install'
+            'Subject'
             'FriendlyName'
             'PfxPass'
             'UseModernPfxEncryption'
@@ -269,7 +276,8 @@ function New-PACertificate {
 
         Complete-PAOrder
 
-    } elseif ($order.CertExpires) {
+    }
+    elseif ($order.CertExpires) {
         Write-Warning "This certificate order has already been completed. Use -Force to overwrite the current certificate."
     }
 }

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -171,6 +171,7 @@ function New-PACertificate {
             if ($oldOrder) {
                 @(  'OCSPMustStaple'
                     'AlwaysNewKey'
+                    'Subject'
                     'FriendlyName'
                     'PfxPass'
                     'UseModernPfxEncryption'

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -194,6 +194,7 @@ function New-PAOrder {
     try {
         $response = Invoke-ACME $header $payloadJson $acct -EA Stop
     } catch { throw }
+
     # process the response
     $order = $response.Content | ConvertFrom-Json
     $order.PSObject.TypeNames.Insert(0,'PoshACME.PAOrder')

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -1,53 +1,53 @@
 function New-PAOrder {
-    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'FromScratch')]
+    [CmdletBinding(SupportsShouldProcess,DefaultParameterSetName='FromScratch')]
     [OutputType('PoshACME.PAOrder')]
     param(
-        [Parameter(ParameterSetName = 'FromScratch', Mandatory, Position = 0)]
-        [Parameter(ParameterSetName = 'ImportKey', Mandatory, Position = 0)]
+        [Parameter(ParameterSetName='FromScratch',Mandatory,Position=0)]
+        [Parameter(ParameterSetName='ImportKey',Mandatory,Position=0)]
         [string[]]$Domain,
-        [Parameter(ParameterSetName = 'FromCSR', Mandatory, Position = 0)]
+        [Parameter(ParameterSetName='FromCSR',Mandatory,Position=0)]
         [string]$CSRPath,
-        [Parameter(ParameterSetName = 'FromScratch', Position = 1)]
-        [ValidateScript({ Test-ValidKeyLength $_ -ThrowOnFail })]
-        [string]$KeyLength = '2048',
-        [Parameter(ParameterSetName = 'ImportKey', Mandatory)]
+        [Parameter(ParameterSetName='FromScratch',Position=1)]
+        [ValidateScript({Test-ValidKeyLength $_ -ThrowOnFail})]
+        [string]$KeyLength='2048',
+        [Parameter(ParameterSetName='ImportKey',Mandatory)]
         [string]$KeyFile,
-        [ValidateScript({ Test-ValidFriendlyName $_ -ThrowOnFail })]
+        [ValidateScript({Test-ValidFriendlyName $_ -ThrowOnFail})]
         [string]$Name,
-        [ValidateScript({ Test-ValidPlugin $_ -ThrowOnFail })]
+        [ValidateScript({Test-ValidPlugin $_ -ThrowOnFail})]
         [string[]]$Plugin,
         [hashtable]$PluginArgs,
         [ValidateRange(0, 3650)]
         [int]$LifetimeDays,
         [string[]]$DnsAlias,
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
         [switch]$OCSPMustStaple,
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
         [switch]$AlwaysNewKey,
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
         [string]$Subject,
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
         [string]$FriendlyName,
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
-        [string]$PfxPass = 'poshacme',
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
-        [ValidateScript({ Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail })]
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
+        [string]$PfxPass='poshacme',
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
+        [ValidateScript({Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail})]
         [securestring]$PfxPassSecure,
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
         [switch]$UseModernPfxEncryption,
-        [Parameter(ParameterSetName = 'FromScratch')]
-        [Parameter(ParameterSetName = 'ImportKey')]
+        [Parameter(ParameterSetName='FromScratch')]
+        [Parameter(ParameterSetName='ImportKey')]
         [switch]$Install,
         [switch]$UseSerialValidation,
-        [int]$DnsSleep = 120,
-        [int]$ValidationTimeout = 60,
+        [int]$DnsSleep=120,
+        [int]$ValidationTimeout=60,
         [string]$PreferredChain,
         [switch]$Force
     )
@@ -90,19 +90,18 @@ function New-PAOrder {
         }
 
         # override the existing PfxPass parameter
-        $PfxPass = [pscredential]::new('u', $PfxPassSecure).GetNetworkCredential().Password
+        $PfxPass = [pscredential]::new('u',$PfxPassSecure).GetNetworkCredential().Password
         $PSBoundParameters.PfxPass = $PfxPass
     }
 
     # check for an existing order
     if ($Name) {
         $order = Get-PAOrder -Name $Name
-    }
-    else {
+    } else {
         $order = Get-PAOrder -MainDomain $Domain[0]
 
         # set the default Name to a filesystem friendly version of the first domain
-        $Name = $Domain[0].Replace('*', '!')
+        $Name = $Domain[0].Replace('*','!')
     }
 
     # separate the SANs
@@ -121,20 +120,18 @@ function New-PAOrder {
              ($order.status -eq 'pending' -and (Get-DateTimeOffsetNow) -gt ([DateTimeOffset]::Parse($order.expires))) ))) {
             # do nothing
 
-            # confirm if previous order is still in progress
-        }
-        elseif ($order -and $order.status -in 'pending', 'ready', 'processing') {
+        # confirm if previous order is still in progress
+        } elseif ($order -and $order.status -in 'pending','ready','processing') {
 
             if (-not $PSCmdlet.ShouldContinue("Do you wish to overwrite?",
-                    "Existing order with status $($order.status).")) { return }
+                "Existing order with status $($order.status).")) { return }
 
-            # confirm if previous order not up for renewal
-        }
-        elseif ($order -and $order.status -eq 'valid' -and
+        # confirm if previous order not up for renewal
+        } elseif ($order -and $order.status -eq 'valid' -and
                     (Get-DateTimeOffsetNow) -lt ([DateTimeOffset]::Parse($order.RenewAfter))) {
 
             if (-not $PSCmdlet.ShouldContinue("Do you wish to overwrite?",
-                    "Existing order has not reached suggested renewal window.")) { return }
+                "Existing order has not reached suggested renewal window.")) { return }
         }
     }
 
@@ -158,7 +155,7 @@ function New-PAOrder {
     $reIPv4 = [regex]'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
 
     # build the payload object
-    $payload = @{identifiers = @() }
+    $payload = @{identifiers=@()}
     foreach ($d in $Domain) {
 
         # IP identifiers (RFC8738) are an extension to the original ACME protocol
@@ -174,10 +171,10 @@ function New-PAOrder {
             Write-Debug "$d identified as IP address. Attempting to parse."
             $ip = [ipaddress]$d
 
-            $payload.identifiers += @{type = 'ip'; value = $ip.ToString() }
+            $payload.identifiers += @{type='ip';value=$ip.ToString()}
         }
         else {
-            $payload.identifiers += @{type = 'dns'; value = $d }
+            $payload.identifiers += @{type='dns';value=$d}
         }
 
     }
@@ -195,12 +192,11 @@ function New-PAOrder {
 
     # send the request
     try {
-        $response = Invoke-ACME $header $payloadJson $acct #-EA Stop
-    }
-    catch { throw }
+        $response = Invoke-ACME $header $payloadJson $acct -EA Stop
+    } catch { throw }
     # process the response
     $order = $response.Content | ConvertFrom-Json
-    $order.PSObject.TypeNames.Insert(0, 'PoshACME.PAOrder')
+    $order.PSObject.TypeNames.Insert(0,'PoshACME.PAOrder')
 
     # fix any dates that may have been parsed by PSCore's JSON serializer
     $order.expires = Repair-ISODate $order.expires
@@ -210,8 +206,7 @@ function New-PAOrder {
         $location = $response.Headers['Location'] | Select-Object -First 1
         Write-Debug "Adding location $location"
         $order | Add-Member -MemberType NoteProperty -Name 'location' -Value $location
-    }
-    else {
+    } else {
         try { throw 'No Location header found in newOrder output' }
         catch { $PSCmdlet.ThrowTerminatingError($_) }
     }
@@ -244,7 +239,7 @@ function New-PAOrder {
     # just by parsing it. So we need to query the details for each one in order to put them
     # in the right order
     $auths = Get-PAAuthorization $order.authorizations
-    for ($i = 0; $i -lt $order.identifiers.Count; $i++) {
+    for ($i=0; $i -lt $order.identifiers.Count; $i++) {
         $auth = $auths | Where-Object { $_.fqdn -eq $order.identifiers[$i].value }
         $order.authorizations[$i] = $auth.location
     }
@@ -342,12 +337,12 @@ function New-PAOrder {
     }
 
     # backup any old certs/requests that might exist
-    $oldFiles = Get-ChildItem (Join-Path $order.Folder *) -Include cert.cer, cert.pfx, chain.cer, fullchain.cer, fullchain.pfx
+    $oldFiles = Get-ChildItem (Join-Path $order.Folder *) -Include cert.cer,cert.pfx,chain.cer,fullchain.cer,fullchain.pfx
     $oldFiles | Move-Item -Destination { "$($_.FullName).bak" } -Force
 
     # remove old chain files
     Get-ChildItem (Join-Path $order.Folder 'chain*.cer') -Exclude chain.cer |
-    Remove-Item -Force
+        Remove-Item -Force
 
     # Make a local copy of the private key if it was specified.
     if ('ImportKey' -eq $PSCmdlet.ParameterSetName) {

--- a/Posh-ACME/Public/Set-PAOrder.ps1
+++ b/Posh-ACME/Public/Set-PAOrder.ps1
@@ -152,9 +152,9 @@ function Set-PAOrder {
 
             if ('Subject' -in $psbKeys -and $Subject -ne $order.Subject) {
                 Write-Verbose "Setting Subject to '$Subject'"
+                Write-Warning "Changing the value of Subject only affects future certificates generated with this order. It can not change the state of an existing certificate."
                 $order.Subject = $Subject
                 $saveChanges = $true
-                $rewritePfx = $true
             }
 
             if ('FriendlyName' -in $psbKeys -and $FriendlyName -ne $order.FriendlyName) {

--- a/Posh-ACME/Public/Set-PAOrder.ps1
+++ b/Posh-ACME/Public/Set-PAOrder.ps1
@@ -1,59 +1,59 @@
 function Set-PAOrder {
-    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Edit')]
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName='Edit')]
     param(
-        [Parameter(Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Parameter(Position=0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [string]$MainDomain,
         [Parameter(ValueFromPipelineByPropertyName)]
-        [ValidateScript({ Test-ValidFriendlyName $_ -ThrowOnFail })]
+        [ValidateScript({Test-ValidFriendlyName $_ -ThrowOnFail})]
         [string]$Name,
-        [Parameter(ParameterSetName = 'Revoke', Mandatory)]
+        [Parameter(ParameterSetName='Revoke', Mandatory)]
         [switch]$RevokeCert,
-        [Parameter(ParameterSetName = 'Revoke')]
+        [Parameter(ParameterSetName='Revoke')]
         [switch]$Force,
-        [Parameter(ParameterSetName = 'Edit')]
-        [Parameter(ParameterSetName = 'Revoke')]
+        [Parameter(ParameterSetName='Edit')]
+        [Parameter(ParameterSetName='Revoke')]
         [switch]$NoSwitch,
-        [Parameter(ParameterSetName = 'Edit')]
-        [ValidateScript({ Test-ValidPlugin $_ -ThrowOnFail })]
+        [Parameter(ParameterSetName='Edit')]
+        [ValidateScript({Test-ValidPlugin $_ -ThrowOnFail})]
         [Alias('DnsPlugin')]
         [string[]]$Plugin,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [hashtable]$PluginArgs,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [ValidateRange(0, 3650)]
         [int]$LifetimeDays,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [string[]]$DnsAlias,
-        [Parameter(ParameterSetName = 'Edit')]
-        [ValidateScript({ Test-ValidFriendlyName $_ -ThrowOnFail })]
+        [Parameter(ParameterSetName='Edit')]
+        [ValidateScript({Test-ValidFriendlyName $_ -ThrowOnFail})]
         [string]$NewName,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [ValidateNotNullOrEmpty()]
         [string]$Subject,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [ValidateNotNullOrEmpty()]
         [string]$FriendlyName,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [ValidateNotNullOrEmpty()]
         [string]$PfxPass,
-        [Parameter(ParameterSetName = 'Edit')]
-        [ValidateScript({ Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail })]
+        [Parameter(ParameterSetName='Edit')]
+        [ValidateScript({Test-SecureStringNotNullOrEmpty $_ -ThrowOnFail})]
         [securestring]$PfxPassSecure,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [switch]$UseModernPfxEncryption,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [switch]$Install,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [switch]$OCSPMustStaple,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [int]$DnsSleep,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [int]$ValidationTimeout,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [string]$PreferredChain,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [switch]$AlwaysNewKey,
-        [Parameter(ParameterSetName = 'Edit')]
+        [Parameter(ParameterSetName='Edit')]
         [switch]$UseSerialValidation
     )
 
@@ -74,7 +74,7 @@ function Set-PAOrder {
             }
 
             # override the existing PfxPass parameter
-            $PfxPass = [pscredential]::new('u', $PfxPassSecure).GetNetworkCredential().Password
+            $PfxPass = [pscredential]::new('u',$PfxPassSecure).GetNetworkCredential().Password
             $PSBoundParameters.PfxPass = $PfxPass
         }
     }
@@ -245,8 +245,7 @@ function Set-PAOrder {
                 $cert = $order | Get-PACertificate
                 if ($rewriteCer -and $cert) {
                     Export-PACertFiles $order
-                }
-                elseif ($rewritePfx -and $cert) {
+                } elseif ($rewritePfx -and $cert) {
                     Export-PACertFiles $order -PfxOnly
                 }
             }
@@ -257,8 +256,7 @@ function Set-PAOrder {
                 $newFolder = Join-Path $acct.Folder $NewName
                 if (Test-Path $newFolder) {
                     Write-Error "Failed to rename PAOrder '$($order.Name)'. The path '$newFolder' already exists."
-                }
-                else {
+                } else {
                     try {
                         # rename the dir folder
                         Write-Debug "Renaming '$($order.Name)' order folder to $newFolder"
@@ -285,8 +283,7 @@ function Set-PAOrder {
             }
 
 
-        }
-        else {
+        } else {
             # RevokeCert was specified
 
             # make sure the order has a cert to revoke and that it's not already expired
@@ -309,7 +306,7 @@ function Set-PAOrder {
             # confirm revocation unless -Force was used
             if (-not $Force) {
                 if (-not $PSCmdlet.ShouldContinue("Are you sure you wish to revoke the certificate for order '$($order.Name)'?",
-                        "Revoking a certificate is irreversible and may immediately break any services using it.")) {
+                "Revoking a certificate is irreversible and may immediately break any services using it.")) {
                     Write-Verbose "Revocation aborted for order '$($order.Name)'."
                     return
                 }
@@ -320,11 +317,10 @@ function Set-PAOrder {
             # grab the cert file contents, strip the headers, and join the lines
             $certStart = -1; $certEnd = -1;
             $certLines = Get-Content $certFile
-            for ($i = 0; $i -lt $certLines.Count; $i++) {
+            for ($i=0; $i -lt $certLines.Count; $i++) {
                 if ($certLines[$i] -eq '-----BEGIN CERTIFICATE-----') {
                     $certStart = $i + 1
-                }
-                elseif ($certLines[$i] -eq '-----END CERTIFICATE-----') {
+                } elseif ($certLines[$i] -eq '-----END CERTIFICATE-----') {
                     $certEnd = $i - 1
                     break
                 }
@@ -348,8 +344,7 @@ function Set-PAOrder {
             # send the request
             try {
                 Invoke-ACME $header $payloadJson $acct -EA Stop | Out-Null
-            }
-            catch { throw }
+            } catch { throw }
 
             # refresh the order
             Update-PAOrder $order

--- a/Posh-ACME/en-US/Posh-ACME-help.xml
+++ b/Posh-ACME/en-US/Posh-ACME-help.xml
@@ -2926,6 +2926,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Subject</maml:name>
+          <maml:description>
+            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>FriendlyName</maml:name>
           <maml:description>
             <maml:para>Set a friendly name for the certificate. This will populate the "Friendly Name" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
@@ -3393,6 +3405,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
         <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Subject</maml:name>
+        <maml:description>
+          <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>FriendlyName</maml:name>
         <maml:description>
           <maml:para>Set a friendly name for the certificate. This will populate the "Friendly Name" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
@@ -3718,6 +3742,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Subject</maml:name>
+          <maml:description>
+            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>FriendlyName</maml:name>
           <maml:description>
             <maml:para>Set a friendly name for the certificate. This will populate the "Friendly Name" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
@@ -3963,6 +3999,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
             <maml:uri />
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Subject</maml:name>
+          <maml:description>
+            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>FriendlyName</maml:name>
@@ -4391,6 +4439,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Subject</maml:name>
+        <maml:description>
+          <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>FriendlyName</maml:name>
@@ -6866,6 +6926,18 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Subject</maml:name>
+          <maml:description>
+            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>FriendlyName</maml:name>
           <maml:description>
             <maml:para>The friendly name for the certificate and subsequent renewals. This will populate the "Friendly Name" field in the Windows certificate store when the PFX is imported. Must not be an empty string.</maml:para>
@@ -7129,6 +7201,18 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
         <maml:name>NewName</maml:name>
         <maml:description>
           <maml:para>The new name for this ACME order.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Subject</maml:name>
+        <maml:description>
+          <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>

--- a/Posh-ACME/en-US/Posh-ACME-help.xml
+++ b/Posh-ACME/en-US/Posh-ACME-help.xml
@@ -2928,7 +2928,7 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Subject</maml:name>
           <maml:description>
-            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+            <maml:para>Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3407,7 +3407,7 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>Subject</maml:name>
         <maml:description>
-          <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+          <maml:para>Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -3744,7 +3744,7 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Subject</maml:name>
           <maml:description>
-            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+            <maml:para>Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4003,7 +4003,7 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Subject</maml:name>
           <maml:description>
-            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+            <maml:para>Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4443,7 +4443,7 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>Subject</maml:name>
         <maml:description>
-          <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+          <maml:para>Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -6928,7 +6928,7 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Subject</maml:name>
           <maml:description>
-            <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+            <maml:para>Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -7212,7 +7212,7 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>Subject</maml:name>
         <maml:description>
-          <maml:para>Set a subject for the certificate. This will populate the "Subject" field in the Windows certificate store when the PFX is imported. Defaults to the first item in the Domain parameter.</maml:para>
+          <maml:para>Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>

--- a/docs/Functions/New-PACertificate.md
+++ b/docs/Functions/New-PACertificate.md
@@ -17,7 +17,7 @@ Request a new certificate
 ```powershell
 New-PACertificate [-Domain] <String[]> [-Name <String>] [-Contact <String[]>] [-CertKeyLength <String>]
  [-AlwaysNewKey] [-AcceptTOS] [-AccountKeyLength <String>] [-DirectoryUrl <String>] [-Plugin <String[]>]
- [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple]
+ [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-Subject <String>]
  [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
  [-Install] [-UseSerialValidation] [-Force] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
  [-PreferredChain <String>] [<CommonParameters>]
@@ -313,6 +313,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Subject
+Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.
+
+```yaml
+Type: String
+Parameter Sets: FromScratch
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Functions/New-PAOrder.md
+++ b/docs/Functions/New-PAOrder.md
@@ -17,18 +17,18 @@ Create a new order on the current ACME account.
 ```powershell
 New-PAOrder [-Domain] <String[]> [[-KeyLength] <String>] [-Name <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
- [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
- [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>]
- [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
+ [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
+ [-PreferredChain <String>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ImportKey
 ```powershell
 New-PAOrder [-Domain] <String[]> -KeyFile <String> [-Name <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
- [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
- [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>]
- [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
+ [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
+ [-PreferredChain <String>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### FromCSR
@@ -257,6 +257,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Subject
+Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.
+
+```yaml
+Type: String
+Parameter Sets: FromScratch, ImportKey
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Functions/Set-PAOrder.md
+++ b/docs/Functions/Set-PAOrder.md
@@ -17,9 +17,9 @@ Switch to or modify an order.
 ```powershell
 Set-PAOrder [[-MainDomain] <String>] [-Name <String>] [-NoSwitch] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-NewName <String>]
- [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
- [-Install] [-OCSPMustStaple] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>] [-PreferredChain <String>]
- [-AlwaysNewKey] [-UseSerialValidation] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
+ [-UseModernPfxEncryption] [-Install] [-OCSPMustStaple] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
+ [-PreferredChain <String>] [-AlwaysNewKey] [-UseSerialValidation] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Revoke
@@ -196,6 +196,21 @@ Accept wildcard characters: False
 
 ### -NewName
 The new name for this ACME order.
+
+```yaml
+Type: String
+Parameter Sets: Edit
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Subject
+Sets the x509 "Subject" field in the certificate request that gets sent to the ACME server. By default, it is set to 'CN=FQDN' where 'FQDN' is the first name in the Domain parameter. For public certificate authorities issuing DV certificates, anything other than a DNS name from the list of domains will either be rejected or stripped from the finalized certificate.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Adds a `-Subject` parameter to new orders that allows overriding the default `CN=example.com` generated from the MainDomain on the order. This can be useful for private CAs that allow for additional subject details that public DV CAs don't.