### PR TITLE
Fix All-Inkl plugin's plaintext KasPwd param to actually send the password in plaintext

### DIFF
--- a/Posh-ACME/Plugins/All-Inkl.ps1
+++ b/Posh-ACME/Plugins/All-Inkl.ps1
@@ -212,7 +212,7 @@ function Get-KasLoginDataFromParameters {
     # check which parameter to use and set KAS auth type accordingly
     if ('plain' -eq $paramSetName) {
         $secureAuthData = $KasPwd
-        $kasAuthType = 'sha1'
+        $kasAuthType = 'plain'
     }
     elseif ('sha1' -eq $paramSetName) {
         $secureAuthData = $KasPwdHash
@@ -226,11 +226,6 @@ function Get-KasLoginDataFromParameters {
     # get plaintext from securestring
     $kasAuthData = [pscredential]::new('a',$secureAuthData).GetNetworkCredential().Password
 
-    # when user provided plaintext password, compute sha1 of the password
-    if ('plain' -eq $paramSetName) {
-        $kasAuthData = [System.BitConverter]::ToString($(New-Object System.Security.Cryptography.SHA1CryptoServiceProvider).ComputeHash($([system.Text.Encoding]::UTF8).GetBytes($kasAuthData))).Replace("-", "")
-    }
-
     # return the effective authentication data
     return @{ kas_login=$KasUsername; kas_auth_type=$kasAuthType; kas_auth_data=$kasAuthData }
 
@@ -242,10 +237,9 @@ function Get-KasLoginDataFromParameters {
         KAS API supports three different login types: plain/sha1/session
         see https://kasapi.kasserver.com/dokumentation/phpdoc/
 
-        This plugin uses the types 'sha1' & 'session'.
-        This method accepts the parameters for type 'plain', but the data is converted to 'sha1' before being sent to the API.
-
         By using the type 'session' it is possible to reuse existing sessions when Posh-ACME is used as a part of a larger script.
+
+        All-Inkl.com users have received warnings that sha1 auth option may be discontinued as of Dec 2022.
 
     .PARAMETER paramSetName
         The name of the paramSet that was detected by the public methods of this plugin.


### PR DESCRIPTION
As mentioned in #459, the SHA1 authentication method with All-Inkl is being deprecated and only plaintext auth will be allowed sometime after December 2022. While the current plugin allows for a plaintext password parameter set, it converts that to SHA1 under the hood to avoid needing to send the plaintext password over the network.

However, since plaintext will be the only allowed method going forward, this needs to change so that the plaintext password is passed as-is.

