### PR TITLE
Fix for issue #418. Change Add-Type to native enum

### DIFF
--- a/Posh-ACME/Public/Revoke-PACertificate.ps1
+++ b/Posh-ACME/Public/Revoke-PACertificate.ps1
@@ -14,7 +14,7 @@ function Revoke-PACertificate {
         [string]$CertFile,
         [Parameter(ParameterSetName='CertFile',ValueFromPipelineByPropertyName)]
         [string]$KeyFile,
-        [PoshACME.RevocationReasons]$Reason,
+        [RevocationReasons]$Reason,
         [switch]$Force
     )
 
@@ -171,21 +171,17 @@ function Revoke-PACertificate {
 # that ACME supports.
 # https://datatracker.ietf.org/doc/html/rfc8555#section-7.6
 # https://datatracker.ietf.org/doc/html/rfc5280#section-5.3.1
-if (-not ([System.Management.Automation.PSTypeName]'PoshACME.RevocationReasons').Type)
+if (-not ([System.Management.Automation.PSTypeName]'RevocationReasons').Type)
 {
-    Add-Type @"
-        namespace PoshACME {
-            public enum RevocationReasons {
-                keyCompromise        = 1,
-                cACompromise         = 2,
-                affiliationChanged   = 3,
-                superseded           = 4,
-                cessationOfOperation = 5,
-                certificateHold      = 6,
-                removeFromCRL        = 8,
-                privilegeWithdrawn   = 9,
-                aACompromise         = 10
-            }
-        }
-"@
+	enum RevocationReasons {
+		keyCompromise        = 1
+		cACompromise         = 2
+		affiliationChanged   = 3
+		superseded           = 4
+		cessationOfOperation = 5
+		certificateHold      = 6
+		removeFromCRL        = 8
+		privilegeWithdrawn   = 9
+		aACompromise         = 10
+	}
 }


### PR DESCRIPTION
Hi @rmbolger 

I ran into the problem described in Issue #418. After investigating I identified the part causing the error to be the Add-Type call to add the enum for RevocationReasons. I tested replacing this with the native enum keyword which worked. Enum was introduced in Powershell v5 so this should meet your Powershell version requirements.

As it happens the documentation uses RevocationReasons which the new enum matches as well so the only changes are in the Revoke-PACertificate.ps1 file.
