### PR TITLE
Fix #545 - Replace ternary operator for PS 5.1 compatibility

### DIFF
--- a/Posh-ACME/Plugins/OVH.ps1
+++ b/Posh-ACME/Plugins/OVH.ps1
@@ -408,7 +408,7 @@ function Invoke-OVHRest {
     # add the body if there is one
     if ($Body) { $restArgs.Body = $Body }
 
-    Write-Debug ('{0} {1}{2}' -f $restArgs.Method,$restArgs.Uri,(($Body) ? "`n$Body" : ''))
+    Write-Debug ('{0} {1}{2}' -f $restArgs.Method,$restArgs.Uri,"$($restArgs.Body)")
     $response = Invoke-RestMethod @restArgs @script:UseBasic
     if ($response) {
         Write-Debug "Response:`n$response"


### PR DESCRIPTION
This PR fixes #545 by replacing the ternary operator in a `Write-Debug` string-formatting statement. 

While this change makes the file compatible with PowerShell 5.1, I don't have a way to test the OVH plugin and verify the output of the `Write-Debug` statement is shown correctly with/without a value for `$Body`.