### PR TITLE
Add account limits note in GoDaddy.md

### DIFF
--- a/docs/Plugins/GoDaddy.md
+++ b/docs/Plugins/GoDaddy.md
@@ -2,7 +2,9 @@ title: GoDaddy
 
 # How To Use the GoDaddy DNS Plugin
 
-This plugin works against the [GoDaddy DNS](https://www.godaddy.com) provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.
+This plugin works against the [GoDaddy DNS](https://www.godaddy.com) provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against. 
+
+Note: From April 2024 GoDaddy have introduced API account limits which prevent DNS API access for customers with 10 or more domains on their account. Accounts that don't meet the requirements will receive an Access Denied error when communicating with the API.
 
 ## Setup
 

--- a/docs/Plugins/GoDaddy.md
+++ b/docs/Plugins/GoDaddy.md
@@ -4,7 +4,8 @@ title: GoDaddy
 
 This plugin works against the [GoDaddy DNS](https://www.godaddy.com) provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against. 
 
-Note: From April 2024 GoDaddy have introduced API account limits which prevent DNS API access for customers with less than 10 domains on their account. Existing accounts that don't meet the new requirements will now receive an Access Denied error when communicating with the API.
+!!! warning
+    From April 2024 GoDaddy have introduced API account limits which prevent DNS API access for customers with less than 10 domains on their account. Existing accounts that don't meet the new requirements will now receive an Access Denied error when communicating with the API.
 
 ## Setup
 

--- a/docs/Plugins/GoDaddy.md
+++ b/docs/Plugins/GoDaddy.md
@@ -4,7 +4,7 @@ title: GoDaddy
 
 This plugin works against the [GoDaddy DNS](https://www.godaddy.com) provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against. 
 
-Note: From April 2024 GoDaddy have introduced API account limits which prevent DNS API access for customers with 10 or more domains on their account. Accounts that don't meet the requirements will receive an Access Denied error when communicating with the API.
+Note: From April 2024 GoDaddy have introduced API account limits which prevent DNS API access for customers with less than 10 domains on their account. Existing accounts that don't meet the new requirements will now receive an Access Denied error when communicating with the API.
 
 ## Setup
 


### PR DESCRIPTION
According to GoDaddy API support there are new limits for API access:

> We have recently updated the account requirements to access parts of our production Domains API. As part of this update, access to these APIs are now limited:
> 
>     Availability API: Limited to accounts with 50 or more domains
>     Management and DNS APIs: Limited to accounts with 10 or more domains and/or an active Discount Domain Club plan.
> 
> If you have lost access to these APIs, but feel you meet these requirements, please reply back with your account number and we will review your account and whitelist you if we have denied you access in error.
> 
> Please note that this does not affect your access to any of our OTE APIs.
> 
> If you have any further questions or need assistance with other API questions, please reach out.