### PR TITLE
Add ARI support for draft-03

### DIFF
--- a/Posh-ACME/Private/Update-PAOrder.ps1
+++ b/Posh-ACME/Private/Update-PAOrder.ps1
@@ -60,7 +60,7 @@ function Update-PAOrder {
         {
             Write-Verbose "Checking for updated renewal window via ARI"
             $queryParams = @{
-                Uri = '{0}{1}' -f $ariBase,($Order | Get-PACertificate).ARIId
+                Uri = '{0}/{1}' -f $ariBase,($Order | Get-PACertificate).ARIId
                 UserAgent = $script:USER_AGENT
                 Headers = $script:COMMON_HEADERS
                 ErrorAction = 'Stop'

--- a/Posh-ACME/Private/Update-PAOrder.ps1
+++ b/Posh-ACME/Private/Update-PAOrder.ps1
@@ -55,7 +55,8 @@ function Update-PAOrder {
 
         # Check for ARI renewal window updates if supported and there's an unexpired cert
         # https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#name-getting-renewal-information
-        if (-not $SaveOnly -and ($ariBase = (Get-PAServer).renewalInfo) -and
+        $server = Get-PAServer
+        if (-not $SaveOnly -and -not $server.DisableARI -and ($ariBase = $server.renewalInfo) -and
             $Order.CertExpires -and (Get-DateTimeOffsetNow) -lt [DateTimeOffset]::Parse($Order.CertExpires) )
         {
             Write-Verbose "Checking for updated renewal window via ARI"

--- a/Posh-ACME/Private/Update-PAOrder.ps1
+++ b/Posh-ACME/Private/Update-PAOrder.ps1
@@ -72,23 +72,8 @@ function Update-PAOrder {
                 $resp = Invoke-RestMethod @queryParams @script:UseBasic
                 Write-Debug "Response:`n$($resp|ConvertTo-Json)"
             } catch {
-                # try falling back to the draft-01 ARI ID on a 400 error
-                # which is what Google responds with when you try using the draft-03 ID
-                if ($_.Exception.StatusCode -eq 400) {
-                    Write-Debug "Falling back to ARI draft-01"
-                    $queryParams.Uri = '{0}/{1}' -f $ariBase,$cert.ARIId01
-                    try {
-                        Write-Debug "GET $($queryParams.Uri)"
-                        $resp = Invoke-RestMethod @queryParams @script:UseBasic
-                        Write-Debug "Response:`n$($resp|ConvertTo-Json)"
-                    } catch {
-                        Write-Warning "ARI request failed."
-                        $PSCmdlet.WriteError($_)
-                    }
-                } else {
-                    Write-Warning "ARI request failed."
-                    $PSCmdlet.WriteError($_)
-                }
+                Write-Warning "ARI request failed."
+                $PSCmdlet.WriteError($_)
             }
 
             if ($resp.suggestedWindow) {

--- a/Posh-ACME/Private/Update-PAOrder.ps1
+++ b/Posh-ACME/Private/Update-PAOrder.ps1
@@ -69,6 +69,7 @@ function Update-PAOrder {
             try {
                 Write-Debug "GET $($queryParams.Uri)"
                 $resp = Invoke-RestMethod @queryParams @script:UseBasic
+                Write-Debug "Response:`n$($resp|ConvertTo-Json)"
             } catch { throw }
 
             if ($resp.suggestedWindow) {

--- a/Posh-ACME/Private/Update-PAOrder.ps1
+++ b/Posh-ACME/Private/Update-PAOrder.ps1
@@ -59,8 +59,9 @@ function Update-PAOrder {
             $Order.CertExpires -and (Get-DateTimeOffsetNow) -lt [DateTimeOffset]::Parse($Order.CertExpires) )
         {
             Write-Verbose "Checking for updated renewal window via ARI"
+            $cert = $Order | Get-PACertificate
             $queryParams = @{
-                Uri = '{0}/{1}' -f $ariBase,($Order | Get-PACertificate).ARIId
+                Uri = '{0}/{1}' -f $ariBase,$cert.ARIId
                 UserAgent = $script:USER_AGENT
                 Headers = $script:COMMON_HEADERS
                 ErrorAction = 'Stop'
@@ -70,7 +71,25 @@ function Update-PAOrder {
                 Write-Debug "GET $($queryParams.Uri)"
                 $resp = Invoke-RestMethod @queryParams @script:UseBasic
                 Write-Debug "Response:`n$($resp|ConvertTo-Json)"
-            } catch { throw }
+            } catch {
+                # try falling back to the draft-01 ARI ID on a 400 error
+                # which is what Google responds with when you try using the draft-03 ID
+                if ($_.Exception.StatusCode -eq 400) {
+                    Write-Debug "Falling back to ARI draft-01"
+                    $queryParams.Uri = '{0}/{1}' -f $ariBase,$cert.ARIId01
+                    try {
+                        Write-Debug "GET $($queryParams.Uri)"
+                        $resp = Invoke-RestMethod @queryParams @script:UseBasic
+                        Write-Debug "Response:`n$($resp|ConvertTo-Json)"
+                    } catch {
+                        Write-Warning "ARI request failed."
+                        $PSCmdlet.WriteError($_)
+                    }
+                } else {
+                    Write-Warning "ARI request failed."
+                    $PSCmdlet.WriteError($_)
+                }
+            }
 
             if ($resp.suggestedWindow) {
                 $renewAfter = $resp.suggestedWindow.start

--- a/Posh-ACME/Public/Get-PACertificate.ps1
+++ b/Posh-ACME/Public/Get-PACertificate.ps1
@@ -72,6 +72,15 @@ function Get-PACertificate {
             $serialBytes = $cert.SerialNumber.ToByteArray()
             $ariID = '{0}.{1}' -f (ConvertTo-Base64Url $akiBytes),(ConvertTo-Base64Url $serialBytes)
 
+            # derive the draft-01 ARI ID value which Google seems to still be using
+            # https://www.ietf.org/archive/id/draft-ietf-acme-ari-01.html#section-4.1
+            $certID = [Org.BouncyCastle.Ocsp.CertificateId]::new(
+                [Org.BouncyCastle.Asn1.Nist.NistObjectIdentifiers]::IdSha256.Id,
+                $cert,
+                $cert.SerialNumber
+            )
+            $ariID01 = ConvertTo-Base64Url $certID.ToAsn1Object().GetDerEncoded()
+
             # send the output object to the pipeline
             [pscustomobject]@{
                 PSTypeName = 'PoshACME.PACertificate'
@@ -92,6 +101,7 @@ function Get-PACertificate {
 
                 # add the ARI ID value
                 ARIId = $ariID
+                ARIId01 = $ariID01
 
                 # add the serial
                 Serial = $cert.SerialNumber.ToString()

--- a/Posh-ACME/Public/Get-PACertificate.ps1
+++ b/Posh-ACME/Public/Get-PACertificate.ps1
@@ -94,18 +94,18 @@ function Get-PACertificate {
                 ARIId = $ariID
 
                 # add the serial
-                Serial = $cert.SerialNumber
+                Serial = $cert.SerialNumber.ToString()
 
                 # add the full list of SANs
-                AllSANs = @($altNames)
+                AllSANs = [string[]]@($altNames)
 
                 # add the associated file paths whether they exist or not
-                CertFile      = Join-Path $order.Folder 'cert.cer'
-                KeyFile       = Join-Path $order.Folder 'cert.key'
-                ChainFile     = Join-Path $order.Folder 'chain.cer'
-                FullChainFile = Join-Path $order.Folder 'fullchain.cer'
-                PfxFile       = Join-Path $order.Folder 'cert.pfx'
-                PfxFullChain  = Join-Path $order.Folder 'fullchain.pfx'
+                CertFile      = (Join-Path $order.Folder 'cert.cer').ToString()
+                KeyFile       = (Join-Path $order.Folder 'cert.key').ToString()
+                ChainFile     = (Join-Path $order.Folder 'chain.cer').ToString()
+                FullChainFile = (Join-Path $order.Folder 'fullchain.cer').ToString()
+                PfxFile       = (Join-Path $order.Folder 'cert.pfx').ToString()
+                PfxFullChain  = (Join-Path $order.Folder 'fullchain.pfx').ToString()
 
                 PfxPass = $secPfxPass
             }

--- a/Posh-ACME/Public/Get-PACertificate.ps1
+++ b/Posh-ACME/Public/Get-PACertificate.ps1
@@ -72,15 +72,6 @@ function Get-PACertificate {
             $serialBytes = $cert.SerialNumber.ToByteArray()
             $ariID = '{0}.{1}' -f (ConvertTo-Base64Url $akiBytes),(ConvertTo-Base64Url $serialBytes)
 
-            # derive the draft-01 ARI ID value which Google seems to still be using
-            # https://www.ietf.org/archive/id/draft-ietf-acme-ari-01.html#section-4.1
-            $certID = [Org.BouncyCastle.Ocsp.CertificateId]::new(
-                [Org.BouncyCastle.Asn1.Nist.NistObjectIdentifiers]::IdSha256.Id,
-                $cert,
-                $cert.SerialNumber
-            )
-            $ariID01 = ConvertTo-Base64Url $certID.ToAsn1Object().GetDerEncoded()
-
             # send the output object to the pipeline
             [pscustomobject]@{
                 PSTypeName = 'PoshACME.PACertificate'
@@ -101,7 +92,6 @@ function Get-PACertificate {
 
                 # add the ARI ID value
                 ARIId = $ariID
-                ARIId01 = $ariID01
 
                 # add the serial
                 Serial = $cert.SerialNumber.ToString()

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -54,13 +54,10 @@ function New-PACertificate {
     # grab the set of parameter keys to make comparisons easier later
     $psbKeys = $PSBoundParameters.Keys
 
-    # Make sure we have a server set. But don't override the current
+    # Make sure we have a refreshed server. But don't override the current
     # one unless explicitly specified.
-    if (-not (Get-PAServer) -or 'DirectoryUrl' -in $psbKeys) {
+    if ('DirectoryUrl' -in $psbKeys -or -not (Get-PAServer -Refresh)) {
         Set-PAServer -DirectoryUrl $DirectoryUrl
-    } else {
-        # refresh the directory info (which should also get a fresh nonce)
-        Set-PAServer
     }
     Write-Verbose "Using ACME Server $($script:Dir.location)"
 

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -182,6 +182,11 @@ function New-PACertificate {
                 if ($oldOrder.KeyLength -and 'CertKeyLength' -notin $psbKeys) {
                     $orderParams.KeyLength = $oldOrder.KeyLength
                 }
+
+                # add the cert we're replacing if it exists
+                if ($cert = ($oldOrder | Get-PACertificate)) {
+                    $orderParams.ReplacesCert = $cert.ARIId
+                }
             }
 
             # Make sure FriendlyName is non-empty

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -182,17 +182,18 @@ function New-PACertificate {
                 if ($oldOrder.KeyLength -and 'CertKeyLength' -notin $psbKeys) {
                     $orderParams.KeyLength = $oldOrder.KeyLength
                 }
-
-                # add the cert we're replacing if it exists
-                if ($cert = ($oldOrder | Get-PACertificate)) {
-                    $orderParams.ReplacesCert = $cert.ARIId
-                }
             }
 
             # Make sure FriendlyName is non-empty
             if ([String]::IsNullOrWhiteSpace($orderParams.FriendlyName)) {
                 $orderParams.FriendlyName = $Domain[0]
             }
+        }
+
+        # Add the replaced cert ID if it exists
+        # New-PAOrder will ignore it if the server doesn't support ARI
+        if ($oldOrder -and ($cert = ($oldOrder | Get-PACertificate))) {
+            $orderParams.ReplacesCert = $cert.ARIId
         }
 
         # add common explicit order parameters backed up by old order params

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -200,7 +200,7 @@ function New-PAOrder {
 
     # Add the ARI replaces field if supported and specified
     # https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#name-extensions-to-the-order-obj
-    if ($ReplacesCert -and (Get-PAServer).renewalInfo) {
+    if ($ReplacesCert -and -not (Get-PAServer).DisableARI -and (Get-PAServer).renewalInfo) {
         $payload.replaces = $ReplacesCert
     }
 

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -50,7 +50,8 @@ function New-PAOrder {
         [int]$DnsSleep=120,
         [int]$ValidationTimeout=60,
         [string]$PreferredChain,
-        [switch]$Force
+        [switch]$Force,
+        [string]$ReplacesCert
     )
 
     try {
@@ -195,6 +196,12 @@ function New-PAOrder {
         $notAfter = $now.AddDays($LifetimeDays).ToString('yyyy-MM-ddTHH:mm:ssZ', [Globalization.CultureInfo]::InvariantCulture)
         $payload.notBefore = $notBefore
         $payload.notAfter = $notAfter
+    }
+
+    # Add the ARI replaces field if supported and specified
+    # https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#name-extensions-to-the-order-obj
+    if ($ReplacesCert -and (Get-PAServer).renewalInfo) {
+        $payload.replaces = $ReplacesCert
     }
 
     $payloadJson = $payload | ConvertTo-Json -Depth 5 -Compress

--- a/Posh-ACME/Public/Set-PAServer.ps1
+++ b/Posh-ACME/Public/Set-PAServer.ps1
@@ -15,6 +15,7 @@ function Set-PAServer {
         [Parameter(ValueFromPipelineByPropertyName)]
         [switch]$DisableTelemetry,
         [switch]$UseAltAccountRefresh,
+        [switch]$DisableARI,
         [switch]$NoRefresh,
         [switch]$NoSwitch
     )
@@ -72,6 +73,7 @@ function Set-PAServer {
                     DisableTelemetry = $DisableTelemetry.IsPresent
                     SkipCertificateCheck = $SkipCertificateCheck.IsPresent
                     UseAltAccountRefresh = $UseAltAccountRefresh.IsPresent
+                    DisableARI = $DisableARI.IsPresent
                     newAccount = $null
                     newOrder = $null
                     newNonce = $null
@@ -193,6 +195,12 @@ function Set-PAServer {
         {
             Write-Debug "Setting UseAltAccountRefresh value to $($UseAltAccountRefresh.IsPresent)"
             $newDir | Add-Member 'UseAltAccountRefresh' $UseAltAccountRefresh.IsPresent -Force
+        }
+        if ($PSBoundParameters.ContainsKey('DisableARI') -and
+            $newDir.DisableARI -ne $DisableARI.IsPresent)
+        {
+            Write-Debug "Setting DisableARI value to $($DisableARI.IsPresent)"
+            $newDir | Add-Member 'DisableARI' $DisableARI.IsPresent -Force
         }
 
         # save the object to disk except for the dynamic properties

--- a/Posh-ACME/Public/Set-PAServer.ps1
+++ b/Posh-ACME/Public/Set-PAServer.ps1
@@ -161,6 +161,12 @@ function Set-PAServer {
             $newDir.revokeCert = $dirObj.revokeCert
             $newDir.meta       = $dirObj.meta
 
+            # check for the renewalInfo field
+            if ($dirObj.renewalInfo) {
+                $newDir | Add-Member 'renewalInfo' $dirObj.renewalInfo -Force
+            }
+
+
             # update the nonce value
             if ($response.Headers.ContainsKey($script:HEADER_NONCE)) {
                 $newDir.nonce = $response.Headers[$script:HEADER_NONCE] | Select-Object -First 1

--- a/Posh-ACME/Public/Set-PAServer.ps1
+++ b/Posh-ACME/Public/Set-PAServer.ps1
@@ -163,7 +163,10 @@ function Set-PAServer {
 
             # check for the renewalInfo field
             if ($dirObj.renewalInfo) {
-                $newDir | Add-Member 'renewalInfo' $dirObj.renewalInfo -Force
+                # 2024-05-10 - Boulder (LE) is currently including a trailing
+                # "/" which we need to strip.
+                $ariUrl = $dirObj.renewalInfo.TrimEnd('/')
+                $newDir | Add-Member 'renewalInfo' $ariUrl -Force
             }
 
 

--- a/Posh-ACME/Public/Set-PAServer.ps1
+++ b/Posh-ACME/Public/Set-PAServer.ps1
@@ -163,8 +163,9 @@ function Set-PAServer {
 
             # check for the renewalInfo field
             if ($dirObj.renewalInfo) {
-                # 2024-05-10 - Boulder (LE) is currently including a trailing
-                # "/" which we need to strip.
+                # Boulder (LE) is currently including a trailing "/" which we
+                # need to strip.
+                # Fix PR: https://github.com/letsencrypt/boulder/pull/7482
                 $ariUrl = $dirObj.renewalInfo.TrimEnd('/')
                 $newDir | Add-Member 'renewalInfo' $ariUrl -Force
             }

--- a/Posh-ACME/Public/Set-PAServer.ps1
+++ b/Posh-ACME/Public/Set-PAServer.ps1
@@ -163,11 +163,7 @@ function Set-PAServer {
 
             # check for the renewalInfo field
             if ($dirObj.renewalInfo) {
-                # Boulder (LE) is currently including a trailing "/" which we
-                # need to strip.
-                # Fix PR: https://github.com/letsencrypt/boulder/pull/7482
-                $ariUrl = $dirObj.renewalInfo.TrimEnd('/')
-                $newDir | Add-Member 'renewalInfo' $ariUrl -Force
+                $newDir | Add-Member 'renewalInfo' $dirObj.renewalInfo -Force
             }
 
 

--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -43,7 +43,7 @@ function Submit-Renewal {
                 }
 
                 # trigger an ARI check if supported
-                if ((Get-PAServer).renewalInfo) {
+                if (-not (Get-PAServer).DisableARI -and (Get-PAServer).renewalInfo) {
                     Update-PAOrder -Order $order
                 }
 

--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -42,6 +42,11 @@ function Submit-Renewal {
                     catch { $PSCmdlet.ThrowTerminatingError($_) }
                 }
 
+                # trigger an ARI check if supported
+                if ((Get-PAServer).renewalInfo) {
+                    Update-PAOrder -Order $order
+                }
+
                 # skip if the renewal window hasn't been reached and no -Force
                 if (-not $Force -and $null -ne $order.RenewAfter -and (Get-DateTimeOffsetNow) -lt ([DateTimeOffset]::Parse($order.RenewAfter))) {
                     Write-Warning "Order '$($order.Name)' is not recommended for renewal yet. Use -Force to override."

--- a/Posh-ACME/en-US/Posh-ACME-help.xml
+++ b/Posh-ACME/en-US/Posh-ACME-help.xml
@@ -7591,6 +7591,17 @@ Set-PAOrder example.com -Plugin FakeDNS -PluginArgs $pArgs</dev:code>
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DisableARI</maml:name>
+          <maml:description>
+            <maml:para>Explicitly disables ARI (ACME Renewal Information) for this server even if it claims to support the feature. While the ARI RFC is still in draft status, this should only be necessary if ACME servers move to a newer draft version that breaks compatibility with the version currently supported (draft-03).</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -7682,6 +7693,18 @@ Set-PAOrder example.com -Plugin FakeDNS -PluginArgs $pArgs</dev:code>
         <maml:name>UseAltAccountRefresh</maml:name>
         <maml:description>
           <maml:para>Some ACME CAs do not properly support the standard method to refresh account data. If specified, the module will use an alternate method to refresh account data that seems to work with these CAs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DisableARI</maml:name>
+        <maml:description>
+          <maml:para>Explicitly disables ARI (ACME Renewal Information) for this server even if it claims to support the feature. While the ARI RFC is still in draft status, this should only be necessary if ACME servers move to a newer draft version that breaks compatibility with the version currently supported (draft-03).</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/Posh-ACME/en-US/Posh-ACME-help.xml
+++ b/Posh-ACME/en-US/Posh-ACME-help.xml
@@ -3903,6 +3903,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ReplacesCert</maml:name>
+          <maml:description>
+            <maml:para>The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PAOrder</maml:name>
@@ -4162,6 +4174,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ReplacesCert</maml:name>
+          <maml:description>
+            <maml:para>The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PAOrder</maml:name>
@@ -4313,6 +4337,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
             <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>ReplacesCert</maml:name>
+          <maml:description>
+            <maml:para>The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -4607,6 +4643,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>ReplacesCert</maml:name>
+        <maml:description>
+          <maml:para>The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />

--- a/docs/Functions/New-PAOrder.md
+++ b/docs/Functions/New-PAOrder.md
@@ -19,7 +19,7 @@ New-PAOrder [-Domain] <String[]> [[-KeyLength] <String>] [-Name <String>] [-Plug
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
  [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ImportKey
@@ -28,14 +28,15 @@ New-PAOrder [-Domain] <String[]> -KeyFile <String> [-Name <String>] [-Plugin <St
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
  [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### FromCSR
 ```powershell
 New-PAOrder [-CSRPath] <String> [-Name <String>] [-Plugin <String[]>] [-PluginArgs <Hashtable>]
  [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-UseSerialValidation] [-DnsSleep <Int32>]
- [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## Description
@@ -473,6 +474,21 @@ If specified, PFX files generated from this order will use AES256 with SHA256 fo
 ```yaml
 Type: SwitchParameter
 Parameter Sets: FromScratch, ImportKey
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReplacesCert
+The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).
+
+```yaml
+Type: String
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/docs/Functions/Set-PAServer.md
+++ b/docs/Functions/Set-PAServer.md
@@ -15,7 +15,7 @@ Set the current ACME server and/or its configuration.
 
 ```powershell
 Set-PAServer [[-DirectoryUrl] <String>] [-Name <String>] [-NewName <String>] [-SkipCertificateCheck]
- [-DisableTelemetry] [-UseAltAccountRefresh] [-NoRefresh] [-NoSwitch] [<CommonParameters>]
+ [-DisableTelemetry] [-UseAltAccountRefresh] [-DisableARI] [-NoRefresh] [-NoSwitch] [<CommonParameters>]
 ```
 
 ## Description
@@ -168,6 +168,21 @@ Accept wildcard characters: False
 
 ### -UseAltAccountRefresh
 Some ACME CAs do not properly support the standard method to refresh account data. If specified, the module will use an alternate method to refresh account data that seems to work with these CAs.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableARI
+Explicitly disables ARI (ACME Renewal Information) for this server even if it claims to support the feature. While the ARI RFC is still in draft status, this should only be necessary if ACME servers move to a newer draft version that breaks compatibility with the version currently supported (draft-03).
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
The [ARI (ACME Renewal Information)](https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html) draft standard is approaching finalization and the draft-03 version is currently supported in by both Let's Encrypt and Google Trust Services. This change adds ARI support in the module conditionally on the existence of the `renewalInfo` field in the directory endpoint. As other ACME providers add support, it will be enabled automatically once they start publishing that endpoint.

The following user facing changes are part of this PR:

- `ARIId` and `Serial` fields have been added to the output of `Get-PACertificate`
- `DisableARI` switch added to `Set-PAServer` which disables ARI support for the server even it would otherwise be supported. This will primarily be useful if the ARI draft changes enough to break the current support and CAs update their implementations before the module can be updated. It may also be useful for providers with existing ARI support from an older unsupported draft.
- `ReplacesCert` parameter added to `New-PAOrder` which takes an ARIId string as returned by `Get-PACertificate`. This will be ignored if the current ACME server doesn't support ARI or support has been explicitly disabled via `Set-PAServer`.
- Order refreshes now perform an ARI check if supported and not disabled. The `RenewAfter` field is updated if the response indicates it is necessary.
- `Submit-Renewal` now triggers an order refresh if ARI is supported and not disabled.