### PR TITLE
Fix: Modify domain data extraction method to handle PSCustomObject format with numeric keys

### DIFF
--- a/Posh-ACME/Plugins/WEDOS.ps1
+++ b/Posh-ACME/Plugins/WEDOS.ps1
@@ -260,8 +260,15 @@ function Find-Zone {
     }
 
     # Get all of the domains on the account
-    $zones = Invoke-Wedos dns-domains-list $Credential | Select-Object -Expand domain
-    if (-not $zones) {
+    $wedosResponse = Invoke-Wedos dns-domains-list $Credential
+    
+    if ($null -ne $wedosResponse.domain) {
+        # Extract each domain by accessing the properties of the PSCustomObject
+        $zones = @($wedosResponse.domain.PSObject.Properties | ForEach-Object { $_.Value })
+    
+        # Debug output to confirm zones
+        Write-Debug "Found domains: $($zones | ConvertTo-Json -Depth 10)"
+    } else {
         Write-Warning "No WEDOS hosted domains found."
         return
     }


### PR DESCRIPTION
## Description
This PR updates `$zones` assignment to handle WEDOS API responses where `domain` is structured as a `PSCustomObject` with numeric keys.

## Changes
- Replaced `Select-Object -Expand domain` with `.PSObject.Properties | ForEach-Object { $_.Value }` to handle domains with numeric keys.
- Added debug output to confirm `$zones` contains correct domain data.