### PR TITLE
Fix plugin short name parsing for records that contain the zone name more than once

### DIFF
--- a/Posh-ACME/Plugins/Active24.ps1
+++ b/Posh-ACME/Plugins/Active24.ps1
@@ -31,7 +31,7 @@ function Add-DnsTxt {
 
     # get all the instances of the record
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         $recs = (Invoke-RestMethod "$apiRoot/dns/$zoneName/records/v1" @restParams -Method Get) | ? {$_.name -eq $recShort -and $_.type -eq "TXT"}
     } catch { throw }
 
@@ -104,7 +104,7 @@ function Remove-DnsTxt {
 
     # get all the instances of the record
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         $recs = (Invoke-RestMethod "$apiRoot/dns/$zoneName/records/v1" @restParams -Method Get) | ? {$_.name -eq $recShort -and $_.type -eq "TXT"}
     } catch { throw }
 

--- a/Posh-ACME/Plugins/Aliyun.ps1
+++ b/Posh-ACME/Plugins/Aliyun.ps1
@@ -27,7 +27,7 @@ function Add-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # grab the relative portion of the fqdn
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq $RecordName) { $recShort = '@' }
 
     # query for an existing record
@@ -106,7 +106,7 @@ function Remove-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # grab the relative portion of the fqdn
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq $RecordName) { $recShort = '@' }
 
     # query for an existing record

--- a/Posh-ACME/Plugins/All-Inkl.ps1
+++ b/Posh-ACME/Plugins/All-Inkl.ps1
@@ -26,7 +26,7 @@ function Add-DnsTxt {
     $settingsObj = Get-KASDNSSettings $loginData $RecordName
 
     # remove zone from record name
-    $recNameWithoutZone = ($RecordName -ireplace [regex]::Escape($settingsObj.zone), [string]::Empty).TrimEnd('.')
+    $recNameWithoutZone = $RecordName -ireplace "\.?$([regex]::Escape($settingsObj.zone.TrimEnd('.')))$",''
 
     # search for existing DNS settings for the record
     $existingSettingsItem = Find-KASDNSSettingsItemInList $settingsObj.dnsSettings $recNameWithoutZone $TxtValue
@@ -116,7 +116,7 @@ function Remove-DnsTxt {
     $settingsObj = Get-KASDNSSettings $loginData $RecordName
 
     # remove zone from record name
-    $recNameWithoutZone = ($RecordName -ireplace [regex]::Escape($settingsObj.zone), [string]::Empty).TrimEnd('.')
+    $recNameWithoutZone = $RecordName -ireplace "\.?$([regex]::Escape($settingsObj.zone.TrimEnd('.')))$",''
 
     # search for existing DNS settings for the record
     $existingSettingsItem = Find-KASDNSSettingsItemInList $settingsObj.dnsSettings $recNameWithoutZone $TxtValue

--- a/Posh-ACME/Plugins/AutoDNS.ps1
+++ b/Posh-ACME/Plugins/AutoDNS.ps1
@@ -34,7 +34,7 @@ function Add-DnsTxt {
     # record to the zone now without checking to see if it already exists. During
     # testing, AutoDNS detects the duplicate record and just ignores it. So this is
     # probably fine.
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     $updateBody = "<?xml version=`"1.0`" encoding=`"UTF-8`"?><request>$AuthBlock<task><code>0202001</code><default><rr_add><name>$recShort</name><ttl>600</ttl><type>TXT</type><value>$TxtValue</value></rr_add></default><zone><name>$zoneName</name><system_ns>$zoneNS</system_ns></zone></task></request>"
     try {
         Write-Verbose "Adding a TXT record for $RecordName with value $TxtValue"
@@ -121,7 +121,7 @@ function Remove-DnsTxt {
     # record from the zone now without checking to see if it already exists. During
     # testing, it doesn't seem to care if you try and remove a record that's already
     # gone. So this is fine.
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     $updateBody = "<?xml version=`"1.0`" encoding=`"UTF-8`"?><request>$AuthBlock<task><code>0202001</code><default><rr_rem><name>$recShort</name><ttl>600</ttl><type>TXT</type><value>$TxtValue</value></rr_rem></default><zone><name>$zoneName</name><system_ns>$zoneNS</system_ns></zone></task></request>"
     try {
         Write-Verbose "Removing TXT record for $RecordName with value $TxtValue"

--- a/Posh-ACME/Plugins/Azure.ps1
+++ b/Posh-ACME/Plugins/Azure.ps1
@@ -751,12 +751,13 @@ function Get-AZTxtRecord {
     )
 
     # parse the zone name from the zone id and strip it from $RecordName
-    # to get the relativeRecordSetName
+    # to get the relative name
     $zoneName = $ZoneID.Substring($ZoneID.LastIndexOf('/')+1)
-    $relName = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $relName = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($relName -eq [string]::Empty) {
         $relName = '@'
     }
+    Write-Debug "zoneName = $zoneName, relName = $relName"
 
     $recID = "$ZoneID/TXT/$($relName)"
 

--- a/Posh-ACME/Plugins/BlueCat.ps1
+++ b/Posh-ACME/Plugins/BlueCat.ps1
@@ -128,7 +128,7 @@ function Remove-DnsTxt {
     $proxy = Get-BlueCatWsdlProxy -Username $BlueCatUsername -Password $BlueCatPassword -Uri $BlueCatUri
     $view = Get-View -ConfigurationName $BlueCatConfig -ViewName $BlueCatView -BlueCatProxy $proxy
     $parentZone = Get-ParentZone -AbsoluteName $RecordName -ViewId $view.id -BlueCatProxy $proxy
-    $txtRecordName = ($RecordName -ireplace [regex]::Escape($parentZone.absoluteName), [string]::Empty).TrimEnd('.')
+    $txtRecordName = $RecordName -ireplace "\.?$([regex]::Escape($parentZone.absoluteName.TrimEnd('.')))$",''
     $txtRecords = $proxy.getEntitiesByName($parentZone.id, $txtRecordName, "TXTRecord", 0, [int16]::MaxValue)
     $txtRecords = $txtRecords | ForEach-Object { (ConvertPSObjectToHashtable -InputObject $_) + (StringToHashtable -String $_.properties) }
     $txtRecord = $txtRecords | Where-Object { $_.txt -eq $TxtValue }

--- a/Posh-ACME/Plugins/Bunny.ps1
+++ b/Posh-ACME/Plugins/Bunny.ps1
@@ -35,7 +35,7 @@ function Add-DnsTxt {
 
     # check if TXT record with this value already exists
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneResult.ZoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneResult.ZoneName.TrimEnd('.')))$",''
         $resultSet = (Invoke-RestMethod "$apiRoot/$($zoneResult.Id)" @restParams -Method Get)
         $existingRecs = $resultSet.Records | ? { $_.Name -eq $recShort -and $_.Type -eq 3 -and $_.Value -eq $TxtValue }
     }
@@ -114,7 +114,7 @@ function Remove-DnsTxt {
 
     # get all the instances of the record
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneResult.ZoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneResult.ZoneName.TrimEnd('.')))$",''
         $resultSet = (Invoke-RestMethod "$apiRoot/$($zoneResult.Id)" @restParams -Method Get)
         $existingRecs = $resultSet.Records | ? { $_.Name -eq $recShort -and $_.Type -eq 3 -and $_.Value -eq $TxtValue }
     }

--- a/Posh-ACME/Plugins/ClouDNS.ps1
+++ b/Posh-ACME/Plugins/ClouDNS.ps1
@@ -31,7 +31,7 @@ function Add-DnsTxt {
     try { $zoneName = Find-CDZone $RecordName $body } catch { throw }
     Write-Debug "Found zone $zoneName"
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # search for an existing record
     try { $rec = Get-CDTxtRecord $recShort $TxtValue $zoneName $body } catch { throw }
@@ -117,7 +117,7 @@ function Remove-DnsTxt {
     try { $zoneName = Find-CDZone $RecordName $body } catch { throw }
     Write-Debug "Found zone $zoneName"
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # search for an existing record
     try { $rec = Get-CDTxtRecord $recShort $TxtValue $zoneName $body } catch { throw }

--- a/Posh-ACME/Plugins/Combell.ps1
+++ b/Posh-ACME/Plugins/Combell.ps1
@@ -22,7 +22,7 @@ function Add-DnsTxt {
     $cmdletName = "Add-DnsTxt"
     $zoneName = Find-CombellZone $RecordName $ApiKey $ApiSecret
     Write-Verbose "${cmdletName}: Find domain '$zoneName' for record '$RecordName' - OK"
-    $relativeRecordName = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $relativeRecordName = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     $txtRecords = Get-CombellTxtRecords $zoneName $relativeRecordName $TxtValue $ApiKey $ApiSecret
     $numberOfTxtRecords = $txtRecords.Length
 
@@ -95,7 +95,7 @@ function Remove-DnsTxt {
     $cmdletName = "Remove-DnsTxt"
     $zoneName = Find-CombellZone $RecordName $ApiKey $ApiSecret
     Write-Verbose "${cmdletName}: Find domain '$zoneName' for record '$RecordName' - OK"
-    $relativeRecordName = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $relativeRecordName = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     $txtRecords = Get-CombellTxtRecords $zoneName $relativeRecordName $TxtValue $ApiKey $ApiSecret
     $numberOfTxtRecords = $txtRecords.Length
 
@@ -200,7 +200,7 @@ function Find-CombellZone {
     #      domains exist.
     #      Implementing this requires further investigation though (start by reading
     #      https://api.combell.com/v2/documentation#section/Conventions/Pagination), so if you need this, feel free to
-    #      submit a pull request or an issue - Steven Volckaert, 5 October 2021.   
+    #      submit a pull request or an issue - Steven Volckaert, 5 October 2021.
     $zones = Send-CombellHttpRequest GET "domains?take=1000" $ApiKey $ApiSecret;
 
     # We need to find the deepest sub-zone that can hold the record and add it there, except if there is only the apex

--- a/Posh-ACME/Plugins/Constellix.ps1
+++ b/Posh-ACME/Plugins/Constellix.ps1
@@ -27,7 +27,7 @@ function Add-DnsTxt {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # check for an existing record
     $rec = Get-ConstellixTXTRecord $recShort $zoneID $ConstellixKey $ConstellixSecretInsecure $apiBase
@@ -142,7 +142,7 @@ function Remove-DnsTxt {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # check for an existing record
     $rec = Get-ConstellixTXTRecord $recShort $zoneID $ConstellixKey $ConstellixSecretInsecure $apiBase

--- a/Posh-ACME/Plugins/CoreNetworks.ps1
+++ b/Posh-ACME/Plugins/CoreNetworks.ps1
@@ -28,7 +28,7 @@ function Add-DnsTxt {
     Write-Debug $zoneName
 
     ### Grab the relative portion of the Fully Qualified Domain Name (FQDN)
-    $DnsTxtName = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $DnsTxtName = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     Write-Debug $DnsTxtName
 
     # build the add record query
@@ -120,7 +120,7 @@ function Remove-DnsTxt {
     Write-Debug $zoneName
 
     ### Grab the relative portion of the Fully Qualified Domain Name (FQDN)
-    $DnsTxtName = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $DnsTxtName = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     Write-Debug $DnsTxtName
 
     # build the delete record query

--- a/Posh-ACME/Plugins/DMEasy.ps1
+++ b/Posh-ACME/Plugins/DMEasy.ps1
@@ -35,7 +35,7 @@ function Add-DnsTxt {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     $recRoot = "$apiBase/$zoneID/records"
 
@@ -134,7 +134,7 @@ function Remove-DnsTxt {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     $recRoot = "$apiBase/$zoneID/records"
 

--- a/Posh-ACME/Plugins/DNSPod.ps1
+++ b/Posh-ACME/Plugins/DNSPod.ps1
@@ -51,7 +51,7 @@ function Add-DnsTxt {
         try {
             Write-Verbose "Adding $RecordName with value $TxtValue"
 
-            $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+            $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.name.TrimEnd('.')))$",''
             $addQuery = @{
                 Uri = "$DNSPodApiRoot/Record.Create"
                 Method = 'POST'
@@ -308,7 +308,7 @@ function Get-DNSPodTxtRecord {
     try {
 
         # separate the portion of the name that doesn't contain the zone name
-        $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.name.TrimEnd('.')))$",''
 
         # get record
         $recQuery = @{

--- a/Posh-ACME/Plugins/DNSimple.ps1
+++ b/Posh-ACME/Plugins/DNSimple.ps1
@@ -37,7 +37,7 @@ function Add-DnsTxt {
 
     # get all the instances of the record
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         $uri = "$apiRoot/$acctID/zones/$zoneName/records?name=$recShort&type=TXT&per_page=100"
         Write-Debug "GET $uri"
         $resp = Invoke-RestMethod $uri @commonParams @script:UseBasic
@@ -128,7 +128,7 @@ function Remove-DnsTxt {
 
     # get all the instances of the record
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         $uri = "$apiRoot/$acctID/zones/$zoneName/records?name=$recShort&type=TXT&per_page=100"
         Write-Debug "GET $uri"
         $resp = Invoke-RestMethod $uri @commonParams @script:UseBasic

--- a/Posh-ACME/Plugins/DOcean.ps1
+++ b/Posh-ACME/Plugins/DOcean.ps1
@@ -28,7 +28,7 @@ function Add-DnsTxt {
     $recRoot = "https://api.digitalocean.com/v2/domains/$zoneName/records"
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq [string]::Empty) {
         $recShort = '@'
     }
@@ -125,7 +125,7 @@ function Remove-DnsTxt {
     $recRoot = "https://api.digitalocean.com/v2/domains/$zoneName/records"
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq [string]::Empty) {
         $recShort = '@'
     }

--- a/Posh-ACME/Plugins/DeSEC.ps1
+++ b/Posh-ACME/Plugins/DeSEC.ps1
@@ -236,11 +236,11 @@ function Find-DeSECRRset {
     )
 
     Write-Verbose "Attempting to find hosted zone for $RecordName"
-    if (!($domain = Find-DeSECZone $RecordName $AuthHeader)) {
+    if (!($zoneName = Find-DeSECZone $RecordName $AuthHeader)) {
         throw "Unable to find deSEC hosted zone for $RecordName"
     }
 
-    $subname = ($RecordName -ireplace [regex]::Escape($domain), [string]::Empty).TrimEnd('.')
+    $subname = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # .NET thinks all URLS are Windows filenames (no trailing dot)
     # replace trailing ... with escaped %2e%2e%2e

--- a/Posh-ACME/Plugins/Domeneshop.ps1
+++ b/Posh-ACME/Plugins/Domeneshop.ps1
@@ -24,7 +24,7 @@ function Add-DnsTxt {
     try { $oDomain = Find-DomeneshopZone -RecordName $RecordName -apiAuthorization $Private:apiAuthorization } catch { throw }
     Write-Debug ("Found zone {0} with id {1}" -f $oDomain.domain, $oDomain.id)
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($oDomain.domain), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($oDomain.domain.TrimEnd('.')))$",''
 
     # search for an existing record
     try { $rec = Get-DomeneshopTxtRecord -RecordShortName $recShort -TxtValue $TxtValue -ZoneID $oDomain.id -apiAuthorization $Private:apiAuthorization } catch { throw }
@@ -102,7 +102,7 @@ function Remove-DnsTxt {
     try { $oDomain = Find-DomeneshopZone -RecordName $RecordName -apiAuthorization $Private:apiAuthorization } catch { throw }
     Write-Debug ("Found zone {0} with id {1}" -f $oDomain.domain, $oDomain.id)
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($oDomain.domain), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($oDomain.domain.TrimEnd('.')))$",''
 
     # search for an existing record
     try { $rec = Get-DomeneshopTxtRecord -RecordShortName $recShort -TxtValue $TxtValue -ZoneID $oDomain.id -apiAuthorization $Private:apiAuthorization } catch { throw }

--- a/Posh-ACME/Plugins/Easyname.ps1
+++ b/Posh-ACME/Plugins/Easyname.ps1
@@ -25,7 +25,7 @@ function Add-DnsTxt {
 
         Write-Verbose "Adding a TXT record for $RecordName with value $TxtValue"
 
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
         $addParams = @{
             Uri = "https://my.easyname.com/en/domain/dns/create/domain/$zoneID"

--- a/Posh-ACME/Plugins/FreeDNS.ps1
+++ b/Posh-ACME/Plugins/FreeDNS.ps1
@@ -24,7 +24,7 @@ function Add-DnsTxt {
     Write-Verbose "Found owned domain $($zone.domain) ($($zone.id))"
 
     $rec = Get-FDTxtRecords $zone.id $zone.domain $RecordName $TxtValue
-    $recShort = ($RecordName -ireplace [regex]::Escape($zone.domain), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.domain.TrimEnd('.')))$",''
 
     if ($rec) {
         Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."

--- a/Posh-ACME/Plugins/Gandi.ps1
+++ b/Posh-ACME/Plugins/Gandi.ps1
@@ -35,7 +35,7 @@ function Add-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # find the matching TXT record if it exists
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if (-not $recShort) { $recShort = '@' }
     $recUrl = "https://dns.api.gandi.net/api/v5/domains/$zoneName/records/$recShort/TXT"
     try {
@@ -146,7 +146,7 @@ function Remove-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # find the matching TXT record if it exists
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if (-not $recShort) { $recShort = '@' }
     $recUrl = "https://dns.api.gandi.net/api/v5/domains/$zoneName/records/$recShort/TXT"
     try {

--- a/Posh-ACME/Plugins/GoDaddy.ps1
+++ b/Posh-ACME/Plugins/GoDaddy.ps1
@@ -34,7 +34,7 @@ function Add-DnsTxt {
     if (-not ($zone = Find-GDZone $RecordName $headers $apiRoot)) {
         throw "Unable to find matching zone for $RecordName."
     }
-    $recShort = ($RecordName -ireplace [regex]::Escape($zone), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.TrimEnd('.')))$",''
     if ($recShort -eq '') { $recShort = '@' }
 
     # Get a list of existing TXT records for this record name
@@ -157,7 +157,7 @@ function Remove-DnsTxt {
     if (-not ($zone = Find-GDZone $RecordName $headers $apiRoot)) {
         throw "Unable to find matching zone for $RecordName."
     }
-    $recShort = ($RecordName -ireplace [regex]::Escape($zone), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.TrimEnd('.')))$",''
     if ($recShort -eq '') { $recShort = '@' }
 
     # Get a list of existing TXT records for this record name

--- a/Posh-ACME/Plugins/Hetzner.ps1
+++ b/Posh-ACME/Plugins/Hetzner.ps1
@@ -36,7 +36,7 @@ Function Add-DnsTxt {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.name.TrimEnd('.')))$",''
 
     # Get a list of existing TXT records for this record name
     try {
@@ -135,7 +135,7 @@ Function Remove-DnsTxt {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.name.TrimEnd('.')))$",''
 
     # Get a list of existing TXT records for this record name
     try {

--- a/Posh-ACME/Plugins/IBMSoftLayer.ps1
+++ b/Posh-ACME/Plugins/IBMSoftLayer.ps1
@@ -33,7 +33,7 @@ function Add-DnsTxt {
     try { $zoneID,$zoneName = Find-IBMZone $RecordName $IBMCredential $apiBase } catch { throw }
     Write-Debug "Found zone $zoneName with ID $zoneID"
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # search for an existing record
     try { $rec = Get-IBMTxtRecord $zoneID $recShort $TxtValue $IBMCredential $apiBase } catch { throw }
@@ -119,7 +119,7 @@ function Remove-DnsTxt {
     try { $zoneID,$zoneName = Find-IBMZone $RecordName $IBMCredential $apiBase } catch { throw }
     Write-Debug "Found zone $zoneName with ID $zoneID"
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # search for an existing record
     try { $rec = Get-IBMTxtRecord $zoneID $recShort $TxtValue $IBMCredential $apiBase } catch { throw }

--- a/Posh-ACME/Plugins/ISPConfig.ps1
+++ b/Posh-ACME/Plugins/ISPConfig.ps1
@@ -34,7 +34,7 @@ function Add-DnsTxt {
         }
 
         # separate the portion of the name that doesn't contain the zone name
-        $recShort = ("$RecordName." -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         if ($recShort -eq '') { $recShort = "$RecordName." }
 
         # check for an existing record
@@ -139,7 +139,7 @@ function Remove-DnsTxt {
         }
 
         # separate the portion of the name that doesn't contain the zone name
-        $recShort = ("$RecordName." -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         if ($recShort -eq '') { $recShort = "$RecordName." }
 
         # check for an existing record

--- a/Posh-ACME/Plugins/Infomaniak.ps1
+++ b/Posh-ACME/Plugins/Infomaniak.ps1
@@ -35,7 +35,7 @@ Function Add-DnsTxt {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.name.TrimEnd('.')))$",''
 
     # Get a list of existing TXT records for this record name
     try {

--- a/Posh-ACME/Plugins/Linode.ps1
+++ b/Posh-ACME/Plugins/Linode.ps1
@@ -35,7 +35,7 @@ function Add-DnsTxt {
 
     # get all the instances of the record
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         $restParams.Headers.'X-Filter' = @{name=$recShort;type='TXT'} | ConvertTo-Json -Compress
         $recs = (Invoke-RestMethod "$apiRoot/domains/$zoneID/records" @restParams @script:UseBasic).data
     } catch { throw }
@@ -118,7 +118,7 @@ function Remove-DnsTxt {
 
     # get all the instances of the record
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
         $restParams.Headers.'X-Filter' = @{name=$recShort;type='TXT'} | ConvertTo-Json -Compress
         $recs = (Invoke-RestMethod "$apiRoot/domains/$zoneID/records" @restParams @script:UseBasic).data
     } catch { throw }

--- a/Posh-ACME/Plugins/Loopia.ps1
+++ b/Posh-ACME/Plugins/Loopia.ps1
@@ -30,7 +30,7 @@ function Add-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     if (-not (Test-LoopiaSubdomainExists $recShort $zoneName $creds)) {
         # we need to add the "subdomain" object before we add records to it
@@ -109,7 +109,7 @@ function Remove-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     if (-not (Test-LoopiaSubdomainExists $recShort $zoneName $creds)) {
         Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."

--- a/Posh-ACME/Plugins/NameCom.ps1
+++ b/Posh-ACME/Plugins/NameCom.ps1
@@ -35,7 +35,7 @@ function Add-DnsTxt {
         return
     } else {
         # build the body
-        $hostShort = ($RecordName -ireplace [regex]::Escape($domainName), [string]::Empty).TrimEnd('.')
+        $hostShort = $RecordName -ireplace "\.?$([regex]::Escape($domainName.TrimEnd('.')))$",''
         $bodyJson = @{host=$hostShort; type='TXT'; answer=$TxtValue; ttl=300} | ConvertTo-Json -Compress
 
         # add the new record

--- a/Posh-ACME/Plugins/NameSilo.ps1
+++ b/Posh-ACME/Plugins/NameSilo.ps1
@@ -26,7 +26,7 @@ function Add-DnsTxt {
         Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
     } else {
 
-        $recShort = ($RecordName -ireplace [regex]::Escape($zone), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.TrimEnd('.')))$",''
 
         Write-Verbose "Adding a TXT record for $RecordName with value $TxtValue"
         try {

--- a/Posh-ACME/Plugins/Namecheap.ps1
+++ b/Posh-ACME/Plugins/Namecheap.ps1
@@ -28,7 +28,8 @@ function Add-DnsTxt {
     try { $recs = Get-NCRecords $sld $tld $body } catch { throw }
 
     # get the short version of the record name to match against
-    $recMatch = ($RecordName -ireplace [regex]::Escape("$sld.$tld"), [string]::Empty).TrimEnd('.')
+    $zoneName = "$sld.$tld"
+    $recMatch = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # check for an existing record
     if ($recs | Where-Object { $_.Name -eq $recMatch -and $_.Type -eq 'TXT' -and $_.Address -eq $TxtValue }) {
@@ -125,7 +126,8 @@ function Remove-DnsTxt {
     try { $recs = Get-NCRecords $sld $tld $body } catch { throw }
 
     # get the short version of the record name to match against
-    $recMatch = ($RecordName -ireplace [regex]::Escape("$sld.$tld"), [string]::Empty).TrimEnd('.')
+    $zoneName = "$sld.$tld"
+    $recMatch = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     # check for an existing record
     if ($delRec = $recs | Where-Object { $_.Name -eq $recMatch -and $_.Type -eq 'TXT' -and $_.Address -eq $TxtValue }) {

--- a/Posh-ACME/Plugins/OVH.ps1
+++ b/Posh-ACME/Plugins/OVH.ps1
@@ -27,7 +27,7 @@ function Add-DnsTxt {
     Connect-OVH @PSBoundParameters
 
     $domain = Find-OVHDomain $RecordName
-    $recShort = ($RecordName -ireplace [regex]::Escape($domain), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($domain.TrimEnd('.')))$",''
 
     $recs = @(Get-OVHTxtRecords $recShort $domain)
 
@@ -174,7 +174,7 @@ function Remove-DnsTxt {
     Connect-OVH @PSBoundParameters
 
     $domain = Find-OVHDomain $RecordName
-    $recShort = ($RecordName -ireplace [regex]::Escape($domain), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($domain.TrimEnd('.')))$",''
 
     $recs = @(Get-OVHTxtRecords $recShort $domain)
 

--- a/Posh-ACME/Plugins/OnlineNet.ps1
+++ b/Posh-ACME/Plugins/OnlineNet.ps1
@@ -25,7 +25,7 @@ function Add-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # grab the relative portion of the fqdn
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq [string]::Empty) { $recShort = '@' }
 
     $rec = Find-TxtRec $recShort $zoneName $TxtValue $authHeader
@@ -122,7 +122,7 @@ function Remove-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # grab the relative portion of the fqdn
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq [string]::Empty) { $recShort = '@' }
 
     $rec = Find-TxtRec $recShort $zoneName $TxtValue $authHeader

--- a/Posh-ACME/Plugins/PointDNS.ps1
+++ b/Posh-ACME/Plugins/PointDNS.ps1
@@ -26,7 +26,7 @@ function Add-DnsTxt {
     }
 
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.name.TrimEnd('.')))$",''
         $records = Get-PDZoneRecords $zone.id "TXT" $recShort $headers
     } catch { throw }
 
@@ -100,7 +100,7 @@ function Remove-DnsTxt {
     }
 
     try {
-        $recShort = ($RecordName -ireplace [regex]::Escape($zone.name), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.name.TrimEnd('.')))$",''
         $records = Get-PDZoneRecords $zone.id "TXT" $recShort $headers
     } catch { throw }
 

--- a/Posh-ACME/Plugins/Porkbun.ps1
+++ b/Posh-ACME/Plugins/Porkbun.ps1
@@ -32,7 +32,7 @@ function Add-DnsTxt
     # Get the portion of the full name that is the domain name (e.g. 'record.name.sub.example.com' will become 'example.com')
     [string] $DomainName = $DomainInfo.Domain
     # Get the portion of the full name that will become the record name (e.g. 'record.name.sub.example.com' will become 'record.name.sub')
-    [string] $RecordNameShort = ($RecordName -ireplace [Regex]::Escape($DomainName), [string]::Empty).TrimEnd('.')
+    [string] $RecordNameShort = $RecordName -ireplace "\.?$([regex]::Escape($DomainName.TrimEnd('.')))$",''
 
     # Get any existing TXT record(s) that already match what we want to create
     [object[]] $EqualRecords = @($DomainInfo.Records | Where-Object { ($_.type -EQ 'TXT') -AND ($_.name -eq $RecordName) -AND ($_.content -EQ $TxtValue) })

--- a/Posh-ACME/Plugins/PortsManagement.ps1
+++ b/Posh-ACME/Plugins/PortsManagement.ps1
@@ -398,7 +398,7 @@ function Add-PortsDnsRecord {
     }
 
     # Strip the tailing identified zone from record name
-    $RecShort = ($RecordName -ireplace [regex]::Escape($ZoneId), [string]::Empty).TrimEnd('.')
+    $RecShort = $RecordName -ireplace "\.?$([regex]::Escape($ZoneID.TrimEnd('.')))$",''
     if ($RecShort -eq [string]::Empty) {
         $RecShort = '@'
     }
@@ -488,7 +488,7 @@ function Remove-PortsDnsRecord {
     }
 
     # Strip the tailing identified zone from record name
-    $RecShort = ($RecordName -ireplace [regex]::Escape($ZoneId), [string]::Empty).TrimEnd('.')
+    $RecShort = $RecordName -ireplace "\.?$([regex]::Escape($ZoneID.TrimEnd('.')))$",''
     if ($RecShort -eq [string]::Empty) {
         $RecShort = '@'
     }
@@ -547,7 +547,7 @@ function Get-PortsDnsRecord {
         )
     }
     # Strip the tailing identified zone from record name
-    $RecShort = ($RecordName -ireplace [regex]::Escape($ZoneId), [string]::Empty).TrimEnd('.')
+    $RecShort = $RecordName -ireplace "\.?$([regex]::Escape($ZoneID.TrimEnd('.')))$",''
     if ($RecShort -eq [string]::Empty) {
         $RecShort = '@'
     }

--- a/Posh-ACME/Plugins/Regru.ps1
+++ b/Posh-ACME/Plugins/Regru.ps1
@@ -295,7 +295,7 @@ function Get-RrTxtRecord {
     }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneObject.dname), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneObject.dname.TrimEnd('.')))$",''
     if ($recShort -eq '') { $recShort = '@' }
 
     $rec = $zoneObject.rrs | Where-Object {

--- a/Posh-ACME/Plugins/Simply.ps1
+++ b/Posh-ACME/Plugins/Simply.ps1
@@ -243,7 +243,7 @@ function Get-SimplyTXTRecord {
                 if ($RecordName -eq $match.domain.name_idn) {
                     $recShort = '@'
                 } else {
-                    $recShort = ($RecordName -ireplace [regex]::Escape($match.domain.name_idn), [string]::Empty).TrimEnd('.')
+                    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($match.domain.name_idn.TrimEnd('.')))$",''
                 }
 
                 $script:SimplyRecordZones.$RecordName = $zoneID,$recShort

--- a/Posh-ACME/Plugins/SimplyCom.ps1
+++ b/Posh-ACME/Plugins/SimplyCom.ps1
@@ -243,7 +243,7 @@ function Get-SimplyTXTRecord {
                 if ($RecordName -eq $match.domain.name_idn) {
                     $recShort = '@'
                 } else {
-                    $recShort = ($RecordName -ireplace [regex]::Escape($match.domain.name_idn), [string]::Empty).TrimEnd('.')
+                    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($match.domain.name_idn.TrimEnd('.')))$",''
                 }
 
                 $script:SimplyRecordZones.$RecordName = $zoneID,$recShort

--- a/Posh-ACME/Plugins/TencentDNS.ps1
+++ b/Posh-ACME/Plugins/TencentDNS.ps1
@@ -20,7 +20,7 @@ function Add-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # grab the relative portion of the fqdn
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq $RecordName) { $recShort = '@' }
 
     # query for an existing record
@@ -93,7 +93,7 @@ function Remove-DnsTxt {
     Write-Debug "Found zone $zoneName"
 
     # grab the relative portion of the fqdn
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if ($recShort -eq $RecordName) { $recShort = '@' }
 
     # query for an existing record

--- a/Posh-ACME/Plugins/TotalUptime.ps1
+++ b/Posh-ACME/Plugins/TotalUptime.ps1
@@ -22,7 +22,7 @@ function Add-DnsTxt {
     Write-Debug "Found Domain ID $($DomainMetadata.id) for record $RecordName"
 
     #strip domain component from record
-    $recShort = ($RecordName -ireplace [regex]::Escape($DomainMetadata.domainName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($DomainMetadata.domainName.TrimEnd('.')))$",''
     if ($recShort -eq [string]::Empty) {
         $recShort = '@'
     }
@@ -111,7 +111,7 @@ function Remove-DnsTxt {
     }
 
     #Format recordname as short form
-    $recShort = ($RecordName -ireplace [regex]::Escape($DomainMetadata.domainName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($DomainMetadata.domainName.TrimEnd('.')))$",''
     if ($recShort -eq [string]::Empty) {
         $recShort = '@'
     }

--- a/Posh-ACME/Plugins/WEDOS.ps1
+++ b/Posh-ACME/Plugins/WEDOS.ps1
@@ -24,7 +24,7 @@ function Add-DnsTxt {
 
     if (-not (Find-TxtRec $RecordName $TxtValue $zone $WedosCredential)) {
         # empty string short names are ok for zone apex
-        $recShort = ($RecordName -ireplace [regex]::Escape($zone), [string]::Empty).TrimEnd('.')
+        $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.TrimEnd('.')))$",''
         $data = @{
             domain = $zone
             name = $recShort

--- a/Posh-ACME/Plugins/WebsupportSK.ps1
+++ b/Posh-ACME/Plugins/WebsupportSK.ps1
@@ -15,7 +15,7 @@ function Add-DnsTxt {
 
     $zoneName,$zoneID,$zoneRecs = Find-Zone $RecordName $WskCredential
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if (-not $recShort) { $recShort = '@' }
 
     # get all the instances of the record
@@ -83,7 +83,7 @@ function Remove-DnsTxt {
 
     $zoneName,$zoneID,$zoneRecs = Find-Zone $RecordName $WskCredential
 
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     if (-not $recShort) { $recShort = '@' }
 
     # get all the instances of the record

--- a/Posh-ACME/Plugins/Windows.ps1
+++ b/Posh-ACME/Plugins/Windows.ps1
@@ -30,7 +30,7 @@ function Add-DnsTxt {
     $zone = Get-DnsServerZone $zoneName @dnsParams -EA Stop
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     Write-Debug "Record short name: $recShort"
 
     # check for zone scope usage
@@ -130,7 +130,7 @@ function Remove-DnsTxt {
     $zone = Get-DnsServerZone $zoneName @dnsParams -EA Stop
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
     Write-Debug "Record short name: $recShort"
 
     # check for zone scope usage

--- a/Posh-ACME/Plugins/Yandex.ps1
+++ b/Posh-ACME/Plugins/Yandex.ps1
@@ -28,7 +28,7 @@ function Add-DnsTxt {
     } catch { throw }
 
     # separate the portion of the name that doesn't contain the zone name
-    $recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 
     if ($rec) {
         Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."

--- a/docs/Plugins/Plugin-Development-Guide.md
+++ b/docs/Plugins/Plugin-Development-Guide.md
@@ -162,7 +162,7 @@ Many providers will end up needing you to provide a record's relative/short name
 
 ```powershell
 # assumes $zoneName contains the zone name containing the record
-$recShort = ($RecordName -ireplace [regex]::Escape($zoneName), [string]::Empty).TrimEnd('.')
+$recShort = $RecordName -ireplace "\.?$([regex]::Escape($zoneName.TrimEnd('.')))$",''
 ```
 
 Keep in mind that there are cases where `$RecordName` and `$zoneName` can be identical. The code above will set `$recShort` to an empty string. Depending on the provider, this may not be the proper way to reference zone apex records. Some providers expect you to use `@`, others may want the full zone name like `example.com`. So if your provider expects something other than an empty string, make sure you account for it. Here's an example:


### PR DESCRIPTION
Fixes #584

Many DNS plugins use a regex based algorithm documented in the plugin development guide to separate a record label (short name) from its zone name. The previous version of this algorithm didn't account for the edge case where the FQDN might contain the zone name more than once in the string.

So a record like `_acme-challenge.example.com.foo.example.com` in a zone called `example.com` would result in a short name of `_acme-challenge..foo` instead of `_acme-challenge.example.com.foo` preventing the proper creation of the associated TXT record with that provider.

This change fixes that bug in all of the plugins currently implementing it and in the plugin development guide.

Thanks to @andreashaerter for finding the original bug.