### PR TITLE
ACME Profiles Support

### DIFF
--- a/Posh-ACME/Posh-ACME.psd1
+++ b/Posh-ACME/Posh-ACME.psd1
@@ -30,6 +30,7 @@ FunctionsToExport = @(
     'Get-PAOrder'
     'Get-PAPlugin'
     'Get-PAPluginArgs'
+    'Get-PAProfile'
     'Get-PAServer'
     'Install-PACertificate'
     'Invoke-HttpChallengeListener'

--- a/Posh-ACME/Private/Register-ArgCompleters.ps1
+++ b/Posh-ACME/Private/Register-ArgCompleters.ps1
@@ -151,7 +151,7 @@ function Register-ArgCompleters {
         }
     }
 
-    $OrderProfileCommands = 'Get-PAProfile','New-PAOrder','New-PACertificate'
+    $OrderProfileCommands = 'Get-PAProfile','New-PAOrder', 'Set-PAOrder','New-PACertificate'
     Register-ArgumentCompleter -CommandName $OrderProfileCommands -ParameterName 'Profile' -ScriptBlock $OrderProfileCompleter
 
 }

--- a/Posh-ACME/Private/Register-ArgCompleters.ps1
+++ b/Posh-ACME/Private/Register-ArgCompleters.ps1
@@ -140,4 +140,18 @@ function Register-ArgCompleters {
     $DirNameCommands = 'Get-PAServer','Set-PAServer','Remove-PAServer'
     Register-ArgumentCompleter -CommandName $DirNameCommands -ParameterName 'Name' -ScriptBlock $DirNameCompleter
 
+    # (Order)Profile
+    $OrderProfileCompleter = {
+        param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+        # grab the existing server folders to sort through
+        $choices = (Get-PAProfile).Profile
+        $choices | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+            [Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+        }
+    }
+
+    $OrderProfileCommands = 'Get-PAProfile','New-PAOrder','New-PACertificate'
+    Register-ArgumentCompleter -CommandName $OrderProfileCommands -ParameterName 'Profile' -ScriptBlock $OrderProfileCompleter
+
 }

--- a/Posh-ACME/Public/Get-PAProfile.ps1
+++ b/Posh-ACME/Public/Get-PAProfile.ps1
@@ -1,7 +1,7 @@
 function Get-PAProfile {
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
     [OutputType('PoshACME.PAProfile')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
     param(
         [string]$Profile
     )

--- a/Posh-ACME/Public/Get-PAProfile.ps1
+++ b/Posh-ACME/Public/Get-PAProfile.ps1
@@ -1,0 +1,39 @@
+function Get-PAProfile {
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
+    [OutputType('PoshACME.PAProfile')]
+    param(
+        [string]$Profile
+    )
+
+    Begin {
+        # make sure we have a server configured
+        if (-not ($server = Get-PAServer)) {
+            try { throw "No ACME server configured. Run Set-PAServer first." }
+            catch { $PSCmdlet.ThrowTerminatingError($_) }
+        }
+    }
+
+    Process {
+
+        # https://letsencrypt.org/2025/01/09/acme-profiles/
+        # https://www.ietf.org/archive/id/draft-aaron-acme-profiles-00.html
+
+        if (-not $server.meta.profiles) {
+            return
+        }
+
+        # We want to return the data as a list instead of the monolithic object
+        # the JSON converts to where each profile name is a property
+        $profObj = $server.meta.profiles
+        foreach ($profName in $profObj.PSObject.Properties.Name) {
+            if (-not $Profile -or $Profile -eq $profName) {
+                [pscustomobject]@{
+                    PSTypeName = 'PoshACME.PAProfile'
+                    Profile = $profName
+                    ProfileDescription = $profObj.$profName
+                }
+            }
+        }
+    }
+}

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -207,6 +207,7 @@ function New-PACertificate {
             'DnsSleep'
             'ValidationTimeout'
             'PreferredChain'
+            'Profile'
             'UseSerialValidation' ) | ForEach-Object {
 
             if ($_ -in $psbKeys) {
@@ -243,6 +244,7 @@ function New-PACertificate {
             'DnsSleep'
             'ValidationTimeout'
             'PreferredChain'
+            'Profile'
             'UseSerialValidation' ) | ForEach-Object {
 
             if ($_ -in $psbKeys) {

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -1,6 +1,7 @@
 function New-PACertificate {
     [CmdletBinding(DefaultParameterSetName='FromScratch')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText','')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
     param(
         [Parameter(ParameterSetName='FromScratch',Mandatory,Position=0)]
         [string[]]$Domain,
@@ -48,7 +49,8 @@ function New-PACertificate {
         [switch]$Force,
         [int]$DnsSleep=120,
         [int]$ValidationTimeout=60,
-        [string]$PreferredChain
+        [string]$PreferredChain,
+        [string]$Profile
     )
 
     # grab the set of parameter keys to make comparisons easier later

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -1,7 +1,7 @@
 function New-PAOrder {
     [CmdletBinding(SupportsShouldProcess,DefaultParameterSetName='FromScratch')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
     [OutputType('PoshACME.PAOrder')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
     param(
         [Parameter(ParameterSetName='FromScratch',Mandatory,Position=0)]
         [Parameter(ParameterSetName='ImportKey',Mandatory,Position=0)]
@@ -209,7 +209,11 @@ function New-PAOrder {
     # Add the cert profile if specified
     # https://www.ietf.org/archive/id/draft-aaron-acme-profiles-00.html
     if ($Profile) {
-        $payload.profile = $Profile
+        if ($Profile -in (Get-PAProfile).Profile) {
+            $payload.profile = $Profile
+        } else {
+            Write-Warning "Profile '$Profile' is not currently supported on this ACME server. Ignoring profile selection."
+        }
     }
 
     $payloadJson = $payload | ConvertTo-Json -Depth 5 -Compress

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -1,5 +1,6 @@
 function New-PAOrder {
     [CmdletBinding(SupportsShouldProcess,DefaultParameterSetName='FromScratch')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
     [OutputType('PoshACME.PAOrder')]
     param(
         [Parameter(ParameterSetName='FromScratch',Mandatory,Position=0)]
@@ -51,7 +52,8 @@ function New-PAOrder {
         [int]$ValidationTimeout=60,
         [string]$PreferredChain,
         [switch]$Force,
-        [string]$ReplacesCert
+        [string]$ReplacesCert,
+        [string]$Profile
     )
 
     try {
@@ -202,6 +204,12 @@ function New-PAOrder {
     # https://www.ietf.org/archive/id/draft-ietf-acme-ari-03.html#name-extensions-to-the-order-obj
     if ($ReplacesCert -and -not (Get-PAServer).DisableARI -and (Get-PAServer).renewalInfo) {
         $payload.replaces = $ReplacesCert
+    }
+
+    # Add the cert profile if specified
+    # https://www.ietf.org/archive/id/draft-aaron-acme-profiles-00.html
+    if ($Profile) {
+        $payload.profile = $Profile
     }
 
     $payloadJson = $payload | ConvertTo-Json -Depth 5 -Compress

--- a/Posh-ACME/Public/Set-PAOrder.ps1
+++ b/Posh-ACME/Public/Set-PAOrder.ps1
@@ -1,5 +1,6 @@
 function Set-PAOrder {
     [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName='Edit')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable','')]
     param(
         [Parameter(Position=0,ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [string]$MainDomain,
@@ -54,7 +55,9 @@ function Set-PAOrder {
         [Parameter(ParameterSetName='Edit')]
         [switch]$AlwaysNewKey,
         [Parameter(ParameterSetName='Edit')]
-        [switch]$UseSerialValidation
+        [switch]$UseSerialValidation,
+        [Parameter(ParameterSetName='Edit')]
+        [string]$Profile
     )
 
     Begin {
@@ -204,6 +207,18 @@ function Set-PAOrder {
                 $saveChanges = $true
                 $rewritePfx = $true
                 $rewriteCer = $true
+            }
+
+            if ('Profile' -in $psbKeys -and $Profile -ne $order.Profile) {
+                if ($Profile -in (Get-PAProfile).Profile) {
+                    Write-Verbose "Setting Profile to $Profile"
+                    $order | Add-Member 'Profile' $Profile -Force
+                    $saveChanges = $true
+                    $rewritePfx = $false
+                    $rewriteCer = $false
+                } else {
+                    Write-Warning "Profile '$Profile' is not currently supported on this ACME server. Ignoring profile selection."
+                }
             }
 
             if ('AlwaysNewKey' -in $psbKeys -and

--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -101,6 +101,7 @@ function Submit-Renewal {
                 $certParams.DnsSleep            = $order.DnsSleep
                 $certParams.ValidationTimeout   = $order.ValidationTimeout
                 $certParams.PreferredChain      = $order.PreferredChain
+                $certParams.Profile             = $order.Profile
 
                 if ($order.LifetimeDays -gt 0) { $certParams.LifetimeDays = $order.LifetimeDays }
 

--- a/Posh-ACME/en-US/Posh-ACME-help.xml
+++ b/Posh-ACME/en-US/Posh-ACME-help.xml
@@ -1474,6 +1474,96 @@ Get-PAAccount -List | %{
   </command:command>
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Get-PAProfile</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PAProfile</command:noun>
+      <maml:description>
+        <maml:para>Get current CA supported certificate/order profiles.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>ACME CAs that implement the ACME profiles extension allow for subscribers to choose from a list of supported certificate profiles when creating a new order. This function returns the currently supported profile details for the current ACME CA. The Profile name is used with the `-Profile` parameter in functions like `New-PACertificate`.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Get-PAProfile</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+          <maml:name>Profile</maml:name>
+          <maml:description>
+            <maml:para>The name of the desired ACME certificate profile. Returns nothing if the profile doesn't exist on this CA.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="none">
+        <maml:name>Profile</maml:name>
+        <maml:description>
+          <maml:para>The name of the desired ACME certificate profile. Returns nothing if the profile doesn't exist on this CA.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PoshACME.PAProfile</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>An profile object.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert />
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>------------------- Example 1: All Profiles -------------------</maml:title>
+        <dev:code>Get-PAProfile</dev:code>
+        <dev:remarks>
+          <maml:para>Get all supported ACME profiles on the current server.</maml:para>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>----------------- Example 2: Specific Profile -----------------</maml:title>
+        <dev:code>Get-PAProfile -Profile tlsserver</dev:code>
+        <dev:remarks>
+          <maml:para>Get a specific ACME profile on the current server.</maml:para>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://poshac.me/docs/v4/Functions/Get-PAProfile/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>New-PAOrder</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>New-PACertificate</maml:linkText>
+        <maml:uri></maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Get-PAServer</command:name>
       <command:verb>Get</command:verb>
       <command:noun>PAServer</command:noun>
@@ -3065,6 +3155,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Profile</maml:name>
+          <maml:description>
+            <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PACertificate</maml:name>
@@ -3241,6 +3343,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
           <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
           <dev:type>
             <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Profile</maml:name>
+          <maml:description>
+            <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3547,6 +3661,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Profile</maml:name>
+        <maml:description>
+          <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />
@@ -3915,6 +4041,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Profile</maml:name>
+          <maml:description>
+            <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PAOrder</maml:name>
@@ -4186,6 +4324,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Profile</maml:name>
+          <maml:description>
+            <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PAOrder</maml:name>
@@ -4345,6 +4495,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           <maml:name>ReplacesCert</maml:name>
           <maml:description>
             <maml:para>The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Profile</maml:name>
+          <maml:description>
+            <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4648,6 +4810,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
         <maml:name>ReplacesCert</maml:name>
         <maml:description>
           <maml:para>The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Profile</maml:name>
+        <maml:description>
+          <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -7146,6 +7320,18 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>Profile</maml:name>
+          <maml:description>
+            <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -7436,6 +7622,18 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>Profile</maml:name>
+        <maml:description>
+          <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
     </command:parameters>
     <command:inputTypes />

--- a/docs/Functions/Get-PAProfile.md
+++ b/docs/Functions/Get-PAProfile.md
@@ -1,0 +1,71 @@
+---
+external help file: Posh-ACME-help.xml
+Module Name: Posh-ACME
+online version: https://poshac.me/docs/v4/Functions/Get-PAProfile/
+schema: 2.0.0
+---
+
+# Get-PAProfile
+
+## Synopsis
+
+Get current CA supported certificate/order profiles.
+
+## Syntax
+
+```powershell
+Get-PAProfile [[-Profile] <String>] [<CommonParameters>]
+```
+
+## Description
+
+ACME CAs that implement the ACME profiles extension allow for subscribers to choose from a list of supported certificate profiles when creating a new order. This function returns the currently supported profile details for the current ACME CA. The Profile name is used with the `-Profile` parameter in functions like `New-PACertificate`.
+
+## Examples
+
+### Example 1: All Profiles
+
+```powershell
+Get-PAProfile
+```
+
+Get all supported ACME profiles on the current server.
+
+### Example 2: Specific Profile
+
+```powershell
+Get-PAProfile -Profile tlsserver
+```
+
+Get a specific ACME profile on the current server.
+
+## Parameters
+
+### -Profile
+The name of the desired ACME certificate profile. Returns nothing if the profile doesn't exist on this CA.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Outputs
+
+### PoshACME.PAProfile
+An profile object.
+
+## Related Links
+
+[New-PAOrder](New-PAOrder.md)
+
+[New-PACertificate](New-PACertificate.md)

--- a/docs/Functions/New-PACertificate.md
+++ b/docs/Functions/New-PACertificate.md
@@ -20,7 +20,7 @@ New-PACertificate [-Domain] <String[]> [-Name <String>] [-Contact <String[]>] [-
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-Subject <String>]
  [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
  [-Install] [-UseSerialValidation] [-Force] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [<CommonParameters>]
+ [-PreferredChain <String>] [-Profile <String>] [<CommonParameters>]
 ```
 
 ### FromCSR
@@ -28,7 +28,7 @@ New-PACertificate [-Domain] <String[]> [-Name <String>] [-Contact <String[]>] [-
 New-PACertificate [-CSRPath] <String> [-Name <String>] [-Contact <String[]>] [-AcceptTOS]
  [-AccountKeyLength <String>] [-DirectoryUrl <String>] [-Plugin <String[]>] [-PluginArgs <Hashtable>]
  [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-UseSerialValidation] [-Force] [-DnsSleep <Int32>]
- [-ValidationTimeout <Int32>] [-PreferredChain <String>] [<CommonParameters>]
+ [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Profile <String>] [<CommonParameters>]
 ```
 
 ## Description
@@ -510,6 +510,21 @@ If specified, PFX files generated from this order will use AES256 with SHA256 fo
 ```yaml
 Type: SwitchParameter
 Parameter Sets: FromScratch
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Profile
+The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.
+
+```yaml
+Type: String
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/docs/Functions/New-PAOrder.md
+++ b/docs/Functions/New-PAOrder.md
@@ -19,7 +19,8 @@ New-PAOrder [-Domain] <String[]> [[-KeyLength] <String>] [-Name <String>] [-Plug
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
  [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### ImportKey
@@ -28,15 +29,16 @@ New-PAOrder [-Domain] <String[]> -KeyFile <String> [-Name <String>] [-Plugin <St
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
  [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### FromCSR
 ```powershell
 New-PAOrder [-CSRPath] <String> [-Name <String>] [-Plugin <String[]>] [-PluginArgs <Hashtable>]
  [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-UseSerialValidation] [-DnsSleep <Int32>]
- [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## Description
@@ -485,6 +487,21 @@ Accept wildcard characters: False
 
 ### -ReplacesCert
 The ARI certificate ID from the ARIId parameter on a PACertificate object returned by Get-PACertificate. This is optional and only used if the server supports the ACME Renewal Information Extension (ARI).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Profile
+The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.
 
 ```yaml
 Type: String

--- a/docs/Functions/Set-PAOrder.md
+++ b/docs/Functions/Set-PAOrder.md
@@ -19,7 +19,8 @@ Set-PAOrder [[-MainDomain] <String>] [-Name <String>] [-NoSwitch] [-Plugin <Stri
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-NewName <String>]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
  [-UseModernPfxEncryption] [-Install] [-OCSPMustStaple] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-AlwaysNewKey] [-UseSerialValidation] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-PreferredChain <String>] [-AlwaysNewKey] [-UseSerialValidation] [-Profile <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### Revoke
@@ -440,6 +441,21 @@ If specified, PFX files generated from this order will use AES256 with SHA256 fo
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: Edit
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Profile
+The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.
+
+```yaml
+Type: String
 Parameter Sets: Edit
 Aliases:
 


### PR DESCRIPTION
This PR adds support for the initial draft of the ACME Profiles Extension which will be required in order to use the new short-lived cert and IP-address cert options from Let's Encrypt later this year.
https://letsencrypt.org/2025/01/09/acme-profiles/
https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/
https://letsencrypt.org/2025/01/16/6-day-and-ip-certs/

* New function `Get-PAProfile` returns the profiles supported by the current ACME server
* New `-Profile` param on `New-PAOrder`, `Set-PAOrder`, and `New-PACertificate` functions with tab-completion for supported values.
* `Submit-Renewal` will attempt to renew with the same profile value as the previous cert.
* If a new order is requested with a profile that doesn't exist, a warning will be generated and the request will fall back to an order with no profile specified.
* Users may need to manually run `Get-PAServer -Refresh` in order to re-cache the directory object for their ACME server to pick up profile changes.