### PR TITLE
feat: Add WinNoCimSession parameter to Windows Plugin

### DIFF
--- a/docs/Plugins/Windows.md
+++ b/docs/Plugins/Windows.md
@@ -39,6 +39,16 @@ $cs = New-CimSession -ComputerName dnsserver.example.com
 $cs = New-CimSession -ComputerName dnsserver.example.com -Credential (Get-Credential)
 ```
 
+Alternatively, many of the DNS commands can also be used with the `-ComputerName` parameter directly without needing to create a CimSession. This method may also require less privileges on the DNS server.
+
+```powershell
+# test by specifying the dns server's FQDN
+Get-DnsServerResourceRecord -Name dns1 -ComputerName dns1.example.com -ZoneName example.com
+
+# test by specifying the domain name, which will resolve to the DNS server
+Get-DnsServerResourceRecord -Name dns1 -ComputerName example.com -ZoneName example.com
+```
+
 In environments where one or both of the client and server are not domain joined, you may need to explicitly connect via HTTPS. This may involve extra steps during setup to enable an HTTPS listener on the server. Here is a [decent guide](https://4sysops.com/archives/powershell-remoting-over-https-with-a-self-signed-ssl-certificate/) on getting things setup with a self-signed certificate, though a trusted certificate would work as well. And here is how to test from the client machine.
 
 ```powershell
@@ -59,6 +69,9 @@ In a domain joined environment, the only required parameter is the hostname or I
 ```powershell
 # domain joined environment, no credentials or SSL needed
 New-PACertificate example.com -Plugin Windows -PluginArgs @{WinServer='dns1.example.com'}
+
+# domain joined environment, without CimSession
+New-PACertificate example.com -Plugin Windows -PluginArgs @{WinServer='dns1.example.com', WinNoCimSession=$true}
 
 # standalone environment, adding credentials and SSL flag
 $pArgs = @{


### PR DESCRIPTION
This pull request introduces a new feature to the `Posh-ACME/Plugins/Windows.ps1` script, allowing users to opt out of using CIM sessions for DNS commandlets. The changes include updates to the `Add-DnsTxt` and `Remove-DnsTxt` functions, as well as documentation updates to reflect the new functionality.

This seems to require less permissions as DNS permissions alone are not enough to establish a CIM Session to the DNS Servers / Domain Controllers.

### New Feature: Opt-out of CIM Sessions

* [`Posh-ACME/Plugins/Windows.ps1`](diffhunk://#diff-27bb51b36d0d20fa1e6ec508d3ddfce095fc0b1a6b1bc81e6515d0628d7903b9R16-R28): Added a new switch parameter `WinNoCimSession` to the `Add-DnsTxt` and `Remove-DnsTxt` functions. This allows users to choose not to use CIM sessions when running DNS commandlets. The script now checks for this parameter and adjusts its behavior accordingly. [[1]](diffhunk://#diff-27bb51b36d0d20fa1e6ec508d3ddfce095fc0b1a6b1bc81e6515d0628d7903b9R16-R28) [[2]](diffhunk://#diff-27bb51b36d0d20fa1e6ec508d3ddfce095fc0b1a6b1bc81e6515d0628d7903b9R93-R95) [[3]](diffhunk://#diff-27bb51b36d0d20fa1e6ec508d3ddfce095fc0b1a6b1bc81e6515d0628d7903b9R124-R136) [[4]](diffhunk://#diff-27bb51b36d0d20fa1e6ec508d3ddfce095fc0b1a6b1bc81e6515d0628d7903b9R202-R204)

### Documentation Updates

* [`docs/Plugins/Windows.md`](diffhunk://#diff-83ef96f953e2752a96c0fe70ece73f8841a7df0d54f8d69417481692f6f16d35R42-R51): Updated the documentation to include examples of using DNS commandlets without CIM sessions. This includes both the command line and the `New-PACertificate` function. [[1]](diffhunk://#diff-83ef96f953e2752a96c0fe70ece73f8841a7df0d54f8d69417481692f6f16d35R42-R51) [[2]](diffhunk://#diff-83ef96f953e2752a96c0fe70ece73f8841a7df0d54f8d69417481692f6f16d35R73-R75)