### PR TITLE
Update Windows.ps1

### DIFF
--- a/Posh-ACME/Plugins/Windows.ps1
+++ b/Posh-ACME/Plugins/Windows.ps1
@@ -275,7 +275,7 @@ function Connect-WinDns {
         Write-Debug "Connecting to $WinServer"
         $cimParams = @{ ComputerName=$WinServer }
         if ($WinCred) { $cimParams.Credential = $WinCred }
-        $sessionOpts = @{}
+        $sessionOpts = @{Protocol='Default'}
         if ($WinUseSSL) { $sessionOpts.UseSsl = $true }
         if ($WinSkipCACheck) { $sessionOpts.SkipCACheck = $true }
         $cimParams.SessionOption = New-CimSessionOption @sessionOpts
@@ -333,3 +333,4 @@ function Find-WinZone {
 
     return $null
 }
+


### PR DESCRIPTION
I get the following error when renewing a Windows DNS cert:

"cmdlet New-CimSessionOption at command pipeline position 1 Supply values for the following parameters:
Protocol:"

Entering 'Default' gets past this prompt. I believe the issue started in v4.29.0 with the changes to the 'New-CimSession'.

Setting $sessionOpts = @{Protocol='Default'} when declaring sessionOpts array fixes the issue for me.