### PR TITLE
Add dns-account-01 support

### DIFF
--- a/Posh-ACME/Private/ConvertTo-AcctDnsLabel.ps1
+++ b/Posh-ACME/Private/ConvertTo-AcctDnsLabel.ps1
@@ -1,0 +1,63 @@
+function ConvertTo-AcctDnsLabel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory,Position=0,ValueFromPipelineByPropertyName)]
+        [Alias('location')]
+        [string]$AccountUri
+    )
+
+    Begin {
+        $sha256 = [Security.Cryptography.SHA256]::Create()
+        [string[]]$b32Dict = 'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','2','3','4','5','6','7'
+    }
+
+    Process {
+
+        # https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/02/
+
+        # Construct the validation domain name by prepending the following two
+        # labels to the domain name being validated:
+        #
+        # "_" || base32(SHA-256(<ACCOUNT_URL>)[0:10]) || "._acme-challenge"
+
+        # - SHA-256 is the SHA hashing operation defined in [RFC6234]
+        # - [0:10] is the operation that selects the first ten bytes
+        #   (bytes 0 through 9 inclusive) from the previous SHA-256
+        #   operation
+        # - base32 is the operation defined in [RFC4648]
+        # - ACCOUNT_URL is defined in [RFC8555], Section 7.3 as the value
+        #   in the Location header field
+        # - The || operator indicates concatenation of strings
+
+        # Hash the AccountURI
+        try {
+            $hashBytes = [byte[]]$sha256.ComputeHash([Text.Encoding]::UTF8.GetBytes($AccountUri))
+        } catch {
+            $PSCmdlet.WriteError($_)
+        }
+
+        # Now Base32 encode the first 10 bytes. This is not the most efficient way
+        # to do Base32 encoding, but good enough for this very constrained purpose.
+
+        # Write-Verbose ($hashBytes[0..9] -join ' ')
+
+        # convert the first 10 bytes into binary and concatenate
+        $hashChunkBinary = -join $hashBytes[0..9].ForEach{
+            [Convert]::ToString($_, 2).PadLeft(8, '0')
+        }
+
+        # Write-Verbose $hashChunkBinary
+
+        # replace each 5-bit group with it's Base32 dictionary character
+        $b32Val = [regex]::Replace($hashChunkBinary, '.{5}', {
+            param($Match)
+            $b32Dict[[Convert]::ToInt32($Match.Value, 2)]
+        })
+
+        '_{0}._acme-challenge' -f $b32Val
+    }
+
+    End {
+        $sha256.Dispose()
+    }
+}

--- a/Posh-ACME/Public/New-PACertificate.ps1
+++ b/Posh-ACME/Public/New-PACertificate.ps1
@@ -47,6 +47,8 @@ function New-PACertificate {
         [switch]$UseSerialValidation,
         [switch]$Force,
         [int]$DnsSleep=120,
+        [ValidateSet('dns-01','dns-account-01')]
+        [string]$DnsVariant,
         [int]$ValidationTimeout=60,
         [string]$PreferredChain,
         [string]$Profile
@@ -216,6 +218,7 @@ function New-PACertificate {
             'LifetimeDays'
             'DnsAlias'
             'DnsSleep'
+            'DnsVariant'
             'ValidationTimeout'
             'PreferredChain'
             'Profile'
@@ -255,6 +258,7 @@ function New-PACertificate {
             'UseModernPfxEncryption'
             'Install'
             'DnsSleep'
+            'DnsVariant'
             'ValidationTimeout'
             'PreferredChain'
             'Profile'

--- a/Posh-ACME/Public/New-PAOrder.ps1
+++ b/Posh-ACME/Public/New-PAOrder.ps1
@@ -48,6 +48,8 @@ function New-PAOrder {
         [switch]$Install,
         [switch]$UseSerialValidation,
         [int]$DnsSleep=120,
+        [ValidateSet('dns-01','dns-account-01')]
+        [string]$DnsVariant,
         [int]$ValidationTimeout=60,
         [string]$PreferredChain,
         [switch]$Force,
@@ -313,6 +315,7 @@ function New-PAOrder {
         Plugin              = @('Manual')
         DnsAlias            = $null
         DnsSleep            = $DnsSleep
+        DnsVariant          = $DnsVariant
         ValidationTimeout   = $ValidationTimeout
         Subject             = $Subject
         FriendlyName        = $FriendlyName

--- a/Posh-ACME/Public/Publish-Challenge.ps1
+++ b/Posh-ACME/Public/Publish-Challenge.ps1
@@ -12,7 +12,8 @@ function Publish-Challenge {
         [string]$Plugin,
         [Parameter(Position=4)]
         [hashtable]$PluginArgs,
-        [string]$DnsAlias
+        [string]$DnsAlias,
+        [string]$DnsVariant
     )
 
     # dot source the plugin file
@@ -21,7 +22,7 @@ function Publish-Challenge {
 
     # All plugins in $script:Plugins should have been validated during module
     # load. So we're not going to do much plugin-specific validation here.
-    Write-Verbose "Publishing challenge for Domain $Domain with Token $Token using Plugin $Plugin and DnsAlias '$DnsAlias'."
+    Write-Verbose "Publishing challenge for Domain $Domain with Token $Token using Plugin $Plugin, DnsAlias '$DnsAlias', and DnsVariant '$DnsVariant'."
 
     # sanitize the $Domain if it was passed in as a wildcard on accident
     if ($Domain -and $Domain.StartsWith('*.')) {
@@ -36,8 +37,11 @@ function Publish-Challenge {
         if (-not [String]::IsNullOrWhiteSpace($DnsAlias)) {
             # always use the alias if it was specified
             $recordName = $DnsAlias
+        } elseif ($DnsVariant -eq 'dns-account-01') {
+            $label = ConvertTo-AcctDnsLabel -AccountUri $Account.Location
+            $recordName = "$label.$Domain"
         } else {
-            # use Domain
+            # use standard dns-01 fqdn
             $recordName = "_acme-challenge.$($Domain)"
         }
 

--- a/Posh-ACME/Public/Set-PAOrder.ps1
+++ b/Posh-ACME/Public/Set-PAOrder.ps1
@@ -49,6 +49,9 @@ function Set-PAOrder {
         [Parameter(ParameterSetName='Edit')]
         [int]$DnsSleep,
         [Parameter(ParameterSetName='Edit')]
+        [ValidateSet('dns-01','dns-account-01')]
+        [string]$DnsVariant,
+        [Parameter(ParameterSetName='Edit')]
         [int]$ValidationTimeout,
         [Parameter(ParameterSetName='Edit')]
         [string]$PreferredChain,
@@ -195,6 +198,12 @@ function Set-PAOrder {
             if ('DnsSleep' -in $psbKeys -and $DnsSleep -ne $order.DnsSleep) {
                 Write-Verbose "Setting DnsSleep to $DnsSleep"
                 $order.DnsSleep = $DnsSleep
+                $saveChanges = $true
+            }
+
+            if ('DnsVariant' -in $psbKeys -and $DnsVariant -ne $order.DnsVariant) {
+                Write-Verbose "Setting DnsVariant to $DnsVariant"
+                $order | Add-Member 'DnsVariant' $DnsVariant -Force
                 $saveChanges = $true
             }
 

--- a/Posh-ACME/Public/Submit-ChallengeValidation.ps1
+++ b/Posh-ACME/Public/Submit-ChallengeValidation.ps1
@@ -104,7 +104,9 @@ function Submit-ChallengeValidation {
                 }
                 $challenge = $auth.challenges | Where-Object { $_.type -eq $chalType }
                 if (-not $challenge) {
-                    throw "$($auth.fqdn) authorization contains no challenges that match $chalType"
+                    try {
+                        throw "$($auth.fqdn) authorization contains no challenges that match $chalType"
+                    } catch { $PSCmdlet.ThrowTerminatingError($_) }
                 }
 
                 if ($Order.UseSerialValidation) {
@@ -181,7 +183,9 @@ function Submit-ChallengeValidation {
                 continue
             } else {
                 #status invalid, revoked, deactivated, or expired
-                throw "$($auth.fqdn) authorization status is '$($auth.status)'. Create a new order and try again."
+                try {
+                    throw "$($auth.fqdn) authorization status is '$($auth.status)'. Create a new order and try again."
+                } catch { $PSCmdlet.ThrowTerminatingError($_) }
             }
         }
 

--- a/Posh-ACME/Public/Submit-ChallengeValidation.ps1
+++ b/Posh-ACME/Public/Submit-ChallengeValidation.ps1
@@ -95,21 +95,35 @@ function Submit-ChallengeValidation {
             $auth = $allAuths[$i]
             if ($auth.status -eq 'pending') {
 
-                # Determine which challenge to publish based on the plugin type
+                # Determine which challenge to publish based on the plugin type and check
+                # for any alternate DNS challenge preference specified in the order
                 $chalType = $script:Plugins.($Order.Plugin[$i]).ChallengeType
+                if ($chalType -eq 'dns-01' -and $Order.DnsVariant -and $Order.DnsVariant -ne 'dns-01') {
+                    $chalType = $Order.DnsVariant
+                    Write-Verbose "Using alternate DNS challenge type '$chalType' for $($auth.fqdn) based on order preference."
+                }
                 $challenge = $auth.challenges | Where-Object { $_.type -eq $chalType }
                 if (-not $challenge) {
-                    throw "$($auth.fqdn) authorization contains no challenges that match $($Order.Plugin[$i]) plugin type, $chalType"
+                    throw "$($auth.fqdn) authorization contains no challenges that match $chalType"
                 }
 
                 if ($Order.UseSerialValidation) {
                     # Publish and validate each challenge separately
+                    $pubParams = @{
+                        Domain = $auth.DNSId
+                        Account = $acct
+                        Token = $challenge.token
+                        Plugin = $Order.Plugin[$i]
+                        PluginArgs = $PluginArgs
+                        DnsAlias = $Order.DnsAlias[$i]
+                        DnsVariant = $Order.DnsVariant
+                    }
                     try {
-                        Publish-Challenge $auth.DNSId $acct $challenge.token $Order.Plugin[$i] $PluginArgs -DnsAlias $Order.DnsAlias[$i]
-                        Save-Challenge $Order.Plugin[$i] $PluginArgs
+                        Publish-Challenge @pubParams
+                        Save-Challenge -Plugin $Order.Plugin[$i] -PluginArgs $PluginArgs
 
                         # sleep while DNS changes propagate if it was a DNS challenge that was published
-                        if ($Order.DnsSleep -gt 0 -and 'dns-01' -eq $chalType) {
+                        if ($Order.DnsSleep -gt 0 -and $chalType -like 'dns-*') {
                             Write-Verbose "Sleeping for $($Order.DnsSleep) seconds while DNS change(s) propagate"
                             Start-SleepProgress $Order.DnsSleep -Activity "Waiting for DNS to propagate"
                         }
@@ -125,14 +139,23 @@ function Submit-ChallengeValidation {
                         $PSCmdlet.ThrowTerminatingError($_)
                     }
                     finally {
-                        Unpublish-Challenge $auth.DNSId $acct $challenge.token $Order.Plugin[$i] $PluginArgs -DnsAlias $Order.DnsAlias[$i]
-                        Save-Challenge $Order.Plugin[$i] $PluginArgs
+                        Unpublish-Challenge @pubParams
+                        Save-Challenge -Plugin $Order.Plugin[$i] -PluginArgs $PluginArgs
                     }
                 }
                 else {
                     try {
                         # Publish each challenge
-                        Publish-Challenge $auth.DNSId $acct $challenge.token $Order.Plugin[$i] $PluginArgs -DnsAlias $Order.DnsAlias[$i]
+                        $pubParams = @{
+                            Domain = $auth.DNSId
+                            Account = $acct
+                            Token = $challenge.token
+                            Plugin = $Order.Plugin[$i]
+                            PluginArgs = $PluginArgs
+                            DnsAlias = $Order.DnsAlias[$i]
+                            DnsVariant = $Order.DnsVariant
+                        }
+                        Publish-Challenge @pubParams
 
                         # save the details of what we published for validation and cleanup later
                         $published += @{
@@ -143,7 +166,8 @@ function Submit-ChallengeValidation {
                             chalType = $chalType
                             chalToken = $challenge.token
                             chalUrl = $challenge.url
-                            DNSAlias = $Order.DnsAlias[$i]
+                            DnsAlias = $Order.DnsAlias[$i]
+                            DnsVariant = $Order.DnsVariant
                         }
                     }
                     catch {
@@ -172,7 +196,7 @@ function Submit-ChallengeValidation {
 
                     # call the Save function for each plugin used
                     $uniquePluginsUsed | ForEach-Object {
-                        Save-Challenge $_ $PluginArgs
+                        Save-Challenge -Plugin $_ -PluginArgs $PluginArgs
                     }
 
                     # sleep while DNS changes propagate if there were DNS challenges published
@@ -196,12 +220,21 @@ function Submit-ChallengeValidation {
             finally {
                 # always cleanup the challenges that were published
                 $published | ForEach-Object {
-                    Unpublish-Challenge $_.identifier $acct $_.chalToken $_.plugin $PluginArgs -DnsAlias $_.DNSAlias
+                    $pubParams = @{
+                        Domain = $_.identifier
+                        Account = $acct
+                        Token = $_.chalToken
+                        Plugin = $_.plugin
+                        PluginArgs = $PluginArgs
+                        DnsAlias = $_.DnsAlias
+                        DnsVariant = $_.DnsVariant
+                    }
+                    Unpublish-Challenge @pubParams
                 }
 
                 # save the cleanup changes
                 $published.plugin | Sort-Object -Unique | ForEach-Object {
-                    Save-Challenge $_ $PluginArgs
+                    Save-Challenge -Plugin $_ -PluginArgs $PluginArgs
                 }
             }
         }

--- a/Posh-ACME/Public/Submit-Renewal.ps1
+++ b/Posh-ACME/Public/Submit-Renewal.ps1
@@ -99,6 +99,7 @@ function Submit-Renewal {
                 $certParams.UseSerialValidation = $order.UseSerialValidation
                 $certParams.Force               = $Force.IsPresent
                 $certParams.DnsSleep            = $order.DnsSleep
+                $certParams.DnsVariant          = $order.DnsVariant
                 $certParams.ValidationTimeout   = $order.ValidationTimeout
                 $certParams.PreferredChain      = $order.PreferredChain
                 $certParams.Profile             = $order.Profile

--- a/Posh-ACME/Public/Unpublish-Challenge.ps1
+++ b/Posh-ACME/Public/Unpublish-Challenge.ps1
@@ -12,7 +12,8 @@ function Unpublish-Challenge {
         [string]$Plugin,
         [Parameter(Position=4)]
         [hashtable]$PluginArgs,
-        [string]$DnsAlias
+        [string]$DnsAlias,
+        [string]$DnsVariant
     )
 
     # dot source the plugin file
@@ -21,7 +22,7 @@ function Unpublish-Challenge {
 
     # All plugins in $script:Plugins should have been validated during module
     # load. So we're not going to do much plugin-specific validation here.
-    Write-Verbose "Unpublishing challenge for Domain $Domain with Token $Token using Plugin $Plugin and DnsAlias '$DnsAlias'."
+    Write-Verbose "Unpublishing challenge for Domain $Domain with Token $Token using Plugin $Plugin, DnsAlias '$DnsAlias', and DnsVariant '$DnsVariant'."
 
     # sanitize the $Domain if it was passed in as a wildcard on accident
     if ($Domain -and $Domain.StartsWith('*.')) {
@@ -36,8 +37,11 @@ function Unpublish-Challenge {
         if (-not [String]::IsNullOrWhiteSpace($DnsAlias)) {
             # always use the alias if it was specified
             $recordName = $DnsAlias
+        } elseif ($DnsVariant -eq 'dns-account-01') {
+            $label = ConvertTo-AcctDnsLabel -AccountUri $Account.Location
+            $recordName = "$label.$Domain"
         } else {
-            # use Domain
+            # use standard dns-01 fqdn
             $recordName = "_acme-challenge.$($Domain)"
         }
 

--- a/Posh-ACME/en-US/Posh-ACME-help.xml
+++ b/Posh-ACME/en-US/Posh-ACME-help.xml
@@ -3167,6 +3167,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PACertificate</maml:name>
@@ -3351,6 +3363,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
           <maml:name>Profile</maml:name>
           <maml:description>
             <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -3666,6 +3690,18 @@ New-PAAccount -ExtAcctKID $eabKID -ExtAcctHMACKey $eabHMAC -Contact 'me@example.
         <maml:name>Profile</maml:name>
         <maml:description>
           <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DnsVariant</maml:name>
+        <maml:description>
+          <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -4053,6 +4089,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PAOrder</maml:name>
@@ -4336,6 +4384,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
       <command:syntaxItem>
         <maml:name>New-PAOrder</maml:name>
@@ -4507,6 +4567,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
           <maml:name>Profile</maml:name>
           <maml:description>
             <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -4830,6 +4902,18 @@ New-PACertificate 'example.com' -Plugin FakeDNS -PluginArgs $pArgs -DnsAlias 'ac
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DnsVariant</maml:name>
+        <maml:description>
+          <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
     </command:parameters>
     <command:inputTypes />
     <command:returnValues>
@@ -4994,6 +5078,18 @@ New-PAOrder -Domain $domains -Plugin FakeDNS -PluginArgs $pArgs</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -5061,6 +5157,18 @@ New-PAOrder -Domain $domains -Plugin FakeDNS -PluginArgs $pArgs</dev:code>
         <maml:name>DnsAlias</maml:name>
         <maml:description>
           <maml:para>When using DNS Alias support with DNS validation plugins, the alias domain that the TXT record will be written to. This should be the complete FQDN including the `_acme-challenge.` prefix if necessary. This field is ignored for non-DNS validation plugins.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DnsVariant</maml:name>
+        <maml:description>
+          <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -7695,6 +7803,18 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -7990,6 +8110,18 @@ Set-PAAccount -UseAltPluginEncryption:$false</dev:code>
         <maml:name>Profile</maml:name>
         <maml:description>
           <maml:para>The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DnsVariant</maml:name>
+        <maml:description>
+          <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -8950,6 +9082,18 @@ Submit-Renewal -PluginArgs $pArgs</dev:code>
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>DnsVariant</maml:name>
+          <maml:description>
+            <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
@@ -9017,6 +9161,18 @@ Submit-Renewal -PluginArgs $pArgs</dev:code>
         <maml:name>DnsAlias</maml:name>
         <maml:description>
           <maml:para>When using DNS Alias support with DNS validation plugins, the alias domain that the TXT record will be removed from. This should be the complete FQDN including the `_acme-challenge.` prefix if necessary. This field is ignored for non-DNS validation plugins.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>DnsVariant</maml:name>
+        <maml:description>
+          <maml:para>The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
         <dev:type>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A [PowerShell](#requirements-and-platform-support) module and [ACME](https://too
 - PowerShell [SecretManagement](https://devblogs.microsoft.com/powershell/secretmanagement-and-secretstore-are-generally-available/) support [(Guide)](https://poshac.me/docs/v4/Guides/Using-SecretManagement/)
 - [ARI (ACME Renewal Information)](https://datatracker.ietf.org/doc/draft-ietf-acme-ari/) support based on draft 07.
 - [ACME Profiles](https://datatracker.ietf.org/doc/draft-ietf-acme-profiles/) support based on draft 00.
+- [dns-account-01](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/02/) experimental support based on draft 02.
 - [dns-persist-01](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-persist/) experimental support based on draft 01.
 
 

--- a/docs/Functions/New-PACertificate.md
+++ b/docs/Functions/New-PACertificate.md
@@ -19,8 +19,8 @@ New-PACertificate [-Domain] <String[]> [-Name <String>] [-Contact <String[]>] [-
  [-AlwaysNewKey] [-AcceptTOS] [-AccountKeyLength <String>] [-DirectoryUrl <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-Subject <String>]
  [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>] [-UseModernPfxEncryption]
- [-Install] [-UseSerialValidation] [-Force] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-Profile <String>] [<CommonParameters>]
+ [-Install] [-UseSerialValidation] [-Force] [-DnsSleep <Int32>] [-DnsVariant <String>]
+ [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Profile <String>] [<CommonParameters>]
 ```
 
 ### FromCSR
@@ -28,7 +28,8 @@ New-PACertificate [-Domain] <String[]> [-Name <String>] [-Contact <String[]>] [-
 New-PACertificate [-CSRPath] <String> [-Name <String>] [-Contact <String[]>] [-AcceptTOS]
  [-AccountKeyLength <String>] [-DirectoryUrl <String>] [-Plugin <String[]>] [-PluginArgs <Hashtable>]
  [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-UseSerialValidation] [-Force] [-DnsSleep <Int32>]
- [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Profile <String>] [<CommonParameters>]
+ [-DnsVariant <String>] [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Profile <String>]
+ [<CommonParameters>]
 ```
 
 ## Description
@@ -521,6 +522,21 @@ Accept wildcard characters: False
 
 ### -Profile
 The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsVariant
+The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.
 
 ```yaml
 Type: String

--- a/docs/Functions/New-PAOrder.md
+++ b/docs/Functions/New-PAOrder.md
@@ -18,9 +18,9 @@ Create a new order on the current ACME account.
 New-PAOrder [-Domain] <String[]> [[-KeyLength] <String>] [-Name <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
- [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-DnsVariant <String>]
+ [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### ImportKey
@@ -28,17 +28,17 @@ New-PAOrder [-Domain] <String[]> [[-KeyLength] <String>] [-Name <String>] [-Plug
 New-PAOrder [-Domain] <String[]> -KeyFile <String> [-Name <String>] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-OCSPMustStaple] [-AlwaysNewKey]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
- [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-UseModernPfxEncryption] [-Install] [-UseSerialValidation] [-DnsSleep <Int32>] [-DnsVariant <String>]
+ [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### FromCSR
 ```powershell
 New-PAOrder [-CSRPath] <String> [-Name <String>] [-Plugin <String[]>] [-PluginArgs <Hashtable>]
  [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-UseSerialValidation] [-DnsSleep <Int32>]
- [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force] [-ReplacesCert <String>] [-Profile <String>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-DnsVariant <String>] [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-Force]
+ [-ReplacesCert <String>] [-Profile <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## Description
@@ -502,6 +502,21 @@ Accept wildcard characters: False
 
 ### -Profile
 The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsVariant
+The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.
 
 ```yaml
 Type: String

--- a/docs/Functions/Publish-Challenge.md
+++ b/docs/Functions/Publish-Challenge.md
@@ -15,7 +15,7 @@ Publish a challenge using the specified plugin.
 
 ```powershell
 Publish-Challenge [-Domain] <String> [-Account] <Object> [-Token] <String> [-Plugin] <String>
- [[-PluginArgs] <Hashtable>] [-DnsAlias <String>] [<CommonParameters>]
+ [[-PluginArgs] <Hashtable>] [-DnsAlias <String>] [-DnsVariant <String>] [<CommonParameters>]
 ```
 
 ## Description
@@ -170,6 +170,21 @@ Accept wildcard characters: False
 When using DNS Alias support with DNS validation plugins, the alias domain that the TXT record will be written to.
 This should be the complete FQDN including the `_acme-challenge.` prefix if necessary.
 This field is ignored for non-DNS validation plugins.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsVariant
+The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.
 
 ```yaml
 Type: String

--- a/docs/Functions/Set-PAOrder.md
+++ b/docs/Functions/Set-PAOrder.md
@@ -18,9 +18,9 @@ Switch to or modify an order.
 Set-PAOrder [[-MainDomain] <String>] [-Name <String>] [-NoSwitch] [-Plugin <String[]>]
  [-PluginArgs <Hashtable>] [-LifetimeDays <Int32>] [-DnsAlias <String[]>] [-NewName <String>]
  [-Subject <String>] [-FriendlyName <String>] [-PfxPass <String>] [-PfxPassSecure <SecureString>]
- [-UseModernPfxEncryption] [-Install] [-OCSPMustStaple] [-DnsSleep <Int32>] [-ValidationTimeout <Int32>]
- [-PreferredChain <String>] [-AlwaysNewKey] [-UseSerialValidation] [-Profile <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-UseModernPfxEncryption] [-Install] [-OCSPMustStaple] [-DnsSleep <Int32>] [-DnsVariant <String>]
+ [-ValidationTimeout <Int32>] [-PreferredChain <String>] [-AlwaysNewKey] [-UseSerialValidation]
+ [-Profile <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Revoke
@@ -453,6 +453,21 @@ Accept wildcard characters: False
 
 ### -Profile
 The name of the desired ACME certificate profile. This is checked against the profiles supported by the CA and ignored if it doesn't exist.
+
+```yaml
+Type: String
+Parameter Sets: Edit
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsVariant
+The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.
 
 ```yaml
 Type: String

--- a/docs/Functions/Unpublish-Challenge.md
+++ b/docs/Functions/Unpublish-Challenge.md
@@ -15,7 +15,7 @@ Unpublish a challenge using the specified plugin.
 
 ```powershell
 Unpublish-Challenge [-Domain] <String> [-Account] <Object> [-Token] <String> [-Plugin] <String>
- [[-PluginArgs] <Hashtable>] [-DnsAlias <String>] [<CommonParameters>]
+ [[-PluginArgs] <Hashtable>] [-DnsAlias <String>] [-DnsVariant <String>] [<CommonParameters>]
 ```
 
 ## Description
@@ -170,6 +170,21 @@ Accept wildcard characters: False
 When using DNS Alias support with DNS validation plugins, the alias domain that the TXT record will be removed from.
 This should be the complete FQDN including the `_acme-challenge.` prefix if necessary.
 This field is ignored for non-DNS validation plugins.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DnsVariant
+The DNS challenge variant to use for identifiers in this order. Defaults to `dns-01`. Some variants may require advance DNS preparation. This setting is ignored if only HTTP plugins are specified.
 
 ```yaml
 Type: String

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ A [PowerShell](#requirements-and-platform-support) module and [ACME](https://too
 - PowerShell [SecretManagement](https://devblogs.microsoft.com/powershell/secretmanagement-and-secretstore-are-generally-available/) support [(Guide)](Guides/Using-SecretManagement.md)
 - [ARI (ACME Renewal Information)](https://datatracker.ietf.org/doc/draft-ietf-acme-ari/) support based on draft 07.
 - [ACME Profiles](https://datatracker.ietf.org/doc/draft-ietf-acme-profiles/) support based on draft 00.
+- [dns-account-01](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/02/) experimental support based on draft 02.
 - [dns-persist-01](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-persist/) experimental support based on draft 01.
 
 


### PR DESCRIPTION
This change adds experimental support for [draft-ietf-acme-dns-account-label 02](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-account-label/02/), otherwise known as `dns-account-01`. It's a new challenge type that solves the problem of different entities acquiring certs for the same identifier by making the DNS challenge record FQDN unique for each ACME account.

The main user-facing change is a new optional `-DnsVariant` parameter in the following functions which allows for `dns-01` or `dns-account-01` values.
- New-PACertificate
- New-PAOrder
- Set-PAOrder
- Publish-Challenge
- Unpublish-Challenge

When configured on an order or passed directly to `(Un)Publish-Challenge`, the FQDN used for the key authorization value will be set to `_<hash>._acme-challenge.<identifier>` instead of the traditional `_acme-challenge.<identifier>` that `dns-01` uses.

These changes will also likely serve as the basis for supporting the upcoming `dns-persist-01` challenge.