### PR TITLE
Add Hosting.nl DNS-01 plugin

### DIFF
--- a/Posh-ACME/Plugins/HostingNL.ps1
+++ b/Posh-ACME/Plugins/HostingNL.ps1
@@ -191,20 +191,6 @@ function Invoke-HNLRest {
         if ($Body) { Write-Debug $Body }
         return Invoke-RestMethod @params @script:UseBasic
     } catch {
-        # $apiMessage = $null
-        # $errResp = $_.ErrorDetails.Message
-        # if ($errResp) {
-        #     try {
-        #         $parsed = $errResp | ConvertFrom-Json
-        #         if ($parsed.error) { $apiMessage = $parsed.error }
-        #         elseif ($parsed.errors.message) { $apiMessage = $parsed.errors.message }
-        #     } catch {
-        #         Write-Debug "HostingNL: error response body was not JSON: $errResp"
-        #     }
-        # }
-        # if ($apiMessage) {
-        #     throw "HostingNL error: $apiMessage"
-        # }
         throw
     }
 

--- a/Posh-ACME/Plugins/HostingNL.ps1
+++ b/Posh-ACME/Plugins/HostingNL.ps1
@@ -1,80 +1,55 @@
-<#
-.SYNOPSIS
-    Posh-ACME DNS-01 plugin for Hosting.nl (api.hosting.nl)
-
-.DESCRIPTION
-    Uses the Hosting.nl REST API to manage TXT records for DNS-01 validation.
-    Auth is a single static header (API-TOKEN), no login/token-exchange step.
-
-.NOTES
-    API docs: https://api.hosting.nl/api/documentation
-    Reference client: lego's Hosting.nl provider (github.com/go-acme/lego,
-    providers/dns/hostingnl), used to confirm the wire format below since
-    Hosting.nl's own OpenAPI spec doesn't spell out the TXT quoting behavior.
-#>
-
 function Get-CurrentPluginType { 'dns-01' }
 
 function Add-DnsTxt {
-    [CmdletBinding(DefaultParameterSetName='Secure')]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
         [string]$TxtValue,
-        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [Parameter(Mandatory,Position=2)]
         [securestring]$HNLToken,
-        [Parameter(ParameterSetName='DeprecatedInsecure',Mandatory,Position=2)]
-        [string]$HNLTokenInsecure,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
 
-    $RecordName = $RecordName.TrimEnd('.')
+    $HNLTokenInsecure = [pscredential]::new('a', $HNLToken).GetNetworkCredential().Password
 
-    $token = if ($PSCmdlet.ParameterSetName -eq 'Secure') {
-        Unprotect-HNLSecureString -SecureString $HNLToken
-    } else {
-        $HNLTokenInsecure
+    # Normalize the TxtValue to ensure it is wrapped in quotes
+    if ($TxtValue -notmatch '^".*"$') {
+        $TxtValue = "`"$TxtValue`""
     }
 
-    $domain = Find-HNLZone -RecordName $RecordName -Token $token
-    if (-not $domain) {
-        throw "HostingNL: no domain in this account matches $RecordName"
-    }
+    $zone = Find-HNLZone -RecordName $RecordName -Token $HNLTokenInsecure
 
-    $records = @((Invoke-HNLRest -Token $token -Method Get -Path "/domains/$domain/dns").data)
+    $rec = Invoke-HNLRest 'GET' "domains/$zone/dns" $HNLTokenInsecure |
+        Select-Object -ExpandProperty data |
+        Where-Object {
+            $_.type -eq 'TXT' -and
+            $_.name -eq $RecordName -and
+            $_.content -eq $TxtValue
+        }
 
-    $already = $records | Where-Object {
-        $_.type -eq 'TXT' -and $_.name -eq $RecordName -and $_.content.Trim('"') -eq $TxtValue
-    }
-    if ($already) {
-        Write-Verbose "HostingNL: TXT record for $RecordName with this value already exists. Nothing to do."
+    if ($rec) {
+        Write-Debug "Record $RecordName with value $TxtValue already exists. Nothing to do."
         return
     }
 
-    # content is wrapped in literal double quotes to match lego's Hosting.nl
-    # provider, which sends strconv.Quote(value). Hosting.nl stores whatever
-    # is sent, quotes included, so a plugin that omits them writes a record
-    # that reads back differently than one lego wrote. Matching the quoting
-    # keeps Get-DnsTxt/Remove-DnsTxt comparisons correct either way.
-    $body = @(
-        @{
-            name    = $RecordName
-            type    = 'TXT'
-            content = ('"{0}"' -f $TxtValue)
-            ttl     = 300
-        }
-    )
-
-    $null = Invoke-HNLRest -Token $token -Method Post -Path "/domains/$domain/dns" -Body $body
+    # create the record (must be an array, even if only one)
+    $body = ConvertTo-Json -InputObject @(@{
+        name    = $RecordName
+        type    = 'TXT'
+        content = $TxtValue
+        ttl     = 300
+    })
+    $null = Invoke-HNLRest 'POST' "domains/$zone/dns" $HNLTokenInsecure -Body $body
 
     <#
     .SYNOPSIS
         Add a DNS TXT record to Hosting.nl.
 
     .DESCRIPTION
-        Finds the domain that owns RecordName, checks whether a matching TXT
+        Finds the zone that owns RecordName, checks whether a matching TXT
         record already exists, and if not, creates one via the Hosting.nl API.
 
     .PARAMETER RecordName
@@ -86,10 +61,6 @@ function Add-DnsTxt {
     .PARAMETER HNLToken
         The Hosting.nl API token, as a SecureString.
 
-    .PARAMETER HNLTokenInsecure
-        The Hosting.nl API token, as a plain string. Not recommended except
-        for testing or headless automation where SecureString isn't practical.
-
     .PARAMETER ExtraParams
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
 
@@ -97,64 +68,54 @@ function Add-DnsTxt {
         $token = Read-Host 'HostingNL API Token' -AsSecureString
         Add-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLToken $token
 
-        Adds the record using a SecureString token (recommended).
-
-    .EXAMPLE
-        Add-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLTokenInsecure 'my-api-token'
-
-        Adds the record using a plain-string token, for headless automation.
+        Adds the record using a SecureString token.
     #>
 }
 
 function Remove-DnsTxt {
-    [CmdletBinding(DefaultParameterSetName='Secure')]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory,Position=0)]
         [string]$RecordName,
         [Parameter(Mandatory,Position=1)]
         [string]$TxtValue,
-        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [Parameter(Mandatory,Position=2)]
         [securestring]$HNLToken,
-        [Parameter(ParameterSetName='DeprecatedInsecure',Mandatory,Position=2)]
-        [string]$HNLTokenInsecure,
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
 
-    $RecordName = $RecordName.TrimEnd('.')
+    $HNLTokenInsecure = [pscredential]::new('a', $HNLToken).GetNetworkCredential().Password
 
-    $token = if ($PSCmdlet.ParameterSetName -eq 'Secure') {
-        Unprotect-HNLSecureString -SecureString $HNLToken
-    } else {
-        $HNLTokenInsecure
+    # Normalize the TxtValue to ensure it is wrapped in quotes
+    if ($TxtValue -notmatch '^".*"$') {
+        $TxtValue = "`"$TxtValue`""
     }
 
-    $domain = Find-HNLZone -RecordName $RecordName -Token $token
-    if (-not $domain) {
-        throw "HostingNL: no domain in this account matches $RecordName"
-    }
+    $zone = Find-HNLZone -RecordName $RecordName -Token $HNLTokenInsecure
 
-    $records = @((Invoke-HNLRest -Token $token -Method Get -Path "/domains/$domain/dns").data)
+    $rec = Invoke-HNLRest 'GET' "domains/$zone/dns" $HNLTokenInsecure |
+        Select-Object -ExpandProperty data |
+        Where-Object {
+            $_.type -eq 'TXT' -and
+            $_.name -eq $RecordName -and
+            $_.content -eq $TxtValue
+        }
 
-    $match = $records | Where-Object {
-        $_.type -eq 'TXT' -and $_.name -eq $RecordName -and $_.content.Trim('"') -eq $TxtValue
-    } | Select-Object -First 1
-
-    if (-not $match) {
-        Write-Verbose "HostingNL: TXT record for $RecordName with this value does not exist. Nothing to do."
+    if (-not $rec) {
+        Write-Debug "Record $RecordName with value $TxtValue doesn't exist. Nothing to do."
         return
     }
 
-    $body = @(@{ id = $match.id })
-
-    $null = Invoke-HNLRest -Token $token -Method Delete -Path "/domains/$domain/dns" -Body $body
+    $body = ConvertTo-Json -InputObject @(@{ id = $rec.id })
+    $null = Invoke-HNLRest 'DELETE' "domains/$zone/dns" $HNLTokenInsecure -Body $body
 
     <#
     .SYNOPSIS
         Remove a DNS TXT record from Hosting.nl.
 
     .DESCRIPTION
-        Finds the domain that owns RecordName, looks up the matching TXT
+        Finds the zone that owns RecordName, looks up the matching TXT
         record by name and value, and deletes it by id via the Hosting.nl API.
 
     .PARAMETER RecordName
@@ -166,10 +127,6 @@ function Remove-DnsTxt {
     .PARAMETER HNLToken
         The Hosting.nl API token, as a SecureString.
 
-    .PARAMETER HNLTokenInsecure
-        The Hosting.nl API token, as a plain string. Not recommended except
-        for testing or headless automation where SecureString isn't practical.
-
     .PARAMETER ExtraParams
         This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
 
@@ -177,12 +134,7 @@ function Remove-DnsTxt {
         $token = Read-Host 'HostingNL API Token' -AsSecureString
         Remove-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLToken $token
 
-        Removes the record using a SecureString token (recommended).
-
-    .EXAMPLE
-        Remove-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLTokenInsecure 'my-api-token'
-
-        Removes the record using a plain-string token, for headless automation.
+        Removes the record using a SecureString token.
     #>
 }
 
@@ -192,122 +144,15 @@ function Save-DnsTxt {
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
-    <#
-    .SYNOPSIS
-        Not required.
-
-    .DESCRIPTION
-        Hosting.nl's add/delete endpoints apply immediately, so there is no
-        separate commit step.
-
-    .PARAMETER ExtraParams
-        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
-    #>
+    <# Not required. #>
 }
 
-function Get-DnsTxt {
-    [CmdletBinding(DefaultParameterSetName='Secure')]
-    param(
-        [Parameter(Mandatory,Position=0)]
-        [string]$RecordName,
-        [Parameter(ParameterSetName='Secure',Mandatory,Position=1)]
-        [securestring]$HNLToken,
-        [Parameter(ParameterSetName='DeprecatedInsecure',Mandatory,Position=1)]
-        [string]$HNLTokenInsecure,
-        [Parameter(ValueFromRemainingArguments)]
-        $ExtraParams
-    )
-
-    $RecordName = $RecordName.TrimEnd('.')
-
-    $token = if ($PSCmdlet.ParameterSetName -eq 'Secure') {
-        Unprotect-HNLSecureString -SecureString $HNLToken
-    } else {
-        $HNLTokenInsecure
-    }
-
-    $domain = Find-HNLZone -RecordName $RecordName -Token $token
-    if (-not $domain) {
-        throw "HostingNL: no domain in this account matches $RecordName"
-    }
-
-    $records = @((Invoke-HNLRest -Token $token -Method Get -Path "/domains/$domain/dns").data)
-
-    $records |
-        Where-Object { $_.type -eq 'TXT' -and $_.name -eq $RecordName } |
-        ForEach-Object { $_.content.Trim('"') }
-
-    <#
-    .SYNOPSIS
-        Returns the TXT record values currently set for a given record name.
-
-    .DESCRIPTION
-        Finds the domain that owns RecordName and returns the (quote-stripped)
-        content of every TXT record at that name. Not called by Posh-ACME
-        itself; useful for manual verification against a live account.
-
-    .PARAMETER RecordName
-        The fully qualified name of the TXT record.
-
-    .PARAMETER HNLToken
-        The Hosting.nl API token, as a SecureString.
-
-    .PARAMETER HNLTokenInsecure
-        The Hosting.nl API token, as a plain string. Not recommended except
-        for testing or headless automation where SecureString isn't practical.
-
-    .PARAMETER ExtraParams
-        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
-
-    .EXAMPLE
-        $token = Read-Host 'HostingNL API Token' -AsSecureString
-        Get-DnsTxt '_acme-challenge.example.com' -HNLToken $token
-    #>
-}
 
 ############################
 # Helper Functions
 ############################
 
 # API docs: https://api.hosting.nl/api/documentation
-
-$script:HNLApiRoot = 'https://api.hosting.nl'
-
-if (-not $script:HNLDomainCache) { $script:HNLDomainCache = $null }
-
-# Make sure TLS 1.2 is available for the api.hosting.nl calls. Posh-ACME
-# already sets this process-wide before a plugin loads; this only matters if
-# the file is dot-sourced standalone on Windows PowerShell 5.1, whose default
-# can still be TLS 1.0/1.1. OR it in rather than overwrite so we don't disable
-# protocols the host relies on; harmless no-op on PowerShell 7+.
-try {
-    [Net.ServicePointManager]::SecurityProtocol =
-        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-} catch {
-    Write-Debug "HostingNL: could not set TLS 1.2 (likely already modern): $($_.Exception.Message)"
-}
-
-function Unprotect-HNLSecureString {
-    [CmdletBinding()]
-    param([Parameter(Mandatory)][securestring]$SecureString)
-    (New-Object System.Management.Automation.PSCredential('a', $SecureString)).GetNetworkCredential().Password
-
-    <#
-    .SYNOPSIS
-        Converts a SecureString to a plain string.
-
-    .DESCRIPTION
-        Returns the plaintext of a SecureString so it can be sent in the
-        API-TOKEN header. Uses the PSCredential round-trip, which works on both
-        Windows PowerShell 5.1 and PowerShell 7+.
-
-    .PARAMETER SecureString
-        The SecureString to convert.
-
-    .OUTPUTS
-        The plaintext string.
-    #>
-}
 
 # Wraps Invoke-RestMethod with the Hosting.nl auth header and error shape.
 # Hosting.nl reports errors as either {"error": "..."} or
@@ -319,46 +164,47 @@ function Unprotect-HNLSecureString {
 function Invoke-HNLRest {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Token,
-        [Parameter(Mandatory)][string]$Method,
-        [Parameter(Mandatory)][string]$Path,
-        [object]$Body
+        [Parameter(Mandatory,Position=0)][string]$Method,
+        [Parameter(Mandatory,Position=1)][string]$Path,
+        [Parameter(Mandatory,Position=2)][string]$Token,
+        [string]$Body
     )
 
     $params = @{
-        Uri         = "$script:HNLApiRoot$Path"
+        Uri         = "https://api.hosting.nl/$Path"
         Method      = $Method
-        Headers     = @{ 'API-TOKEN' = $Token; 'Accept' = 'application/json' }
-        ContentType = 'application/json'
+        Headers     = @{
+            'API-TOKEN' = $Token
+            'Accept'    = 'application/json'
+        }
         ErrorAction = 'Stop'
         Verbose     = $false
+        Debug       = $false
     }
-    if ($PSBoundParameters.ContainsKey('Body')) {
-        # Pass -InputObject, not the pipeline. Piping a single-element array into
-        # ConvertTo-Json unrolls it and emits a JSON object ({...}); the API's
-        # add/delete endpoints require an array ([{...}]). -InputObject keeps the
-        # array shape for one or many records. Verified on PS 7 and WinPS 5.1.
-        $params.Body = (ConvertTo-Json -InputObject $Body -Depth 5)
+    if ($Body) {
+        $params.Body = $Body
+        $params.ContentType = 'application/json'
     }
 
     try {
         Write-Debug "$Method $($params.Uri)"
+        if ($Body) { Write-Debug $Body }
         return Invoke-RestMethod @params @script:UseBasic
     } catch {
-        $apiMessage = $null
-        $errResp = $_.ErrorDetails.Message
-        if ($errResp) {
-            try {
-                $parsed = $errResp | ConvertFrom-Json
-                if ($parsed.error) { $apiMessage = $parsed.error }
-                elseif ($parsed.errors.message) { $apiMessage = $parsed.errors.message }
-            } catch {
-                Write-Debug "HostingNL: error response body was not JSON: $errResp"
-            }
-        }
-        if ($apiMessage) {
-            throw "HostingNL: $Method $Path failed: $apiMessage"
-        }
+        # $apiMessage = $null
+        # $errResp = $_.ErrorDetails.Message
+        # if ($errResp) {
+        #     try {
+        #         $parsed = $errResp | ConvertFrom-Json
+        #         if ($parsed.error) { $apiMessage = $parsed.error }
+        #         elseif ($parsed.errors.message) { $apiMessage = $parsed.errors.message }
+        #     } catch {
+        #         Write-Debug "HostingNL: error response body was not JSON: $errResp"
+        #     }
+        # }
+        # if ($apiMessage) {
+        #     throw "HostingNL error: $apiMessage"
+        # }
         throw
     }
 
@@ -371,14 +217,14 @@ function Invoke-HNLRest {
         serializes any body to a JSON array, and on failure rethrows the message
         Hosting.nl returns in the response body instead of a generic HTTP status.
 
-    .PARAMETER Token
-        The Hosting.nl API token, as plaintext.
-
     .PARAMETER Method
         The HTTP method: Get, Post, or Delete.
 
     .PARAMETER Path
         The request path appended to https://api.hosting.nl, for example /domains.
+
+    .PARAMETER Token
+        The Hosting.nl API token, as plaintext.
 
     .PARAMETER Body
         Optional request body (a PowerShell object or array) sent as JSON.
@@ -388,66 +234,47 @@ function Invoke-HNLRest {
     #>
 }
 
-# Pages through GET /domains (Hosting.nl caps the response per call, hence
-# limit/offset) and returns the longest domain name that owns RecordName,
-# the same "prefer the longest owned match" rule the TransIP plugin uses.
-# Needed here because an account can hold both a parent and a delegated
-# child zone. Results are cached per plugin invocation of the dot-sourced
-# script; Add/Remove/Get each get a fresh process from Posh-ACME per run.
 function Find-HNLZone {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$RecordName,
-        [Parameter(Mandatory)][string]$Token
+        [Parameter(Mandatory,Position=0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position=1)]
+        [string]$Token
     )
 
-    # $null (not just falsy) means "not fetched yet": an account with zero domains
-    # caches as @(), which is falsy, so a -not guard would re-page every call.
-    if ($null -eq $script:HNLDomainCache) {
-        $limit = 100
-        $offset = 0
-        $all = @()
-        do {
-            $page = Invoke-HNLRest -Token $Token -Method Get -Path "/domains?limit=$limit&offset=$offset"
-            $pageData = @($page.data)
-            $all += $pageData
-            $offset += $limit
-        } while ($pageData.Count -ge $limit)
+    if (-not $script:HNLRecordZones) { $script:HNLRecordZones = @{} }
 
-        $script:HNLDomainCache = @($all | ForEach-Object { $_.domain } | Where-Object { $_ })
+    if ($script:HNLRecordZones.ContainsKey($RecordName)) {
+        return $script:HNLRecordZones[$RecordName]
     }
 
-    $cleanName = $RecordName.TrimEnd('.')
-    $best = $null
-    foreach ($d in $script:HNLDomainCache) {
-        # -like, not .EndsWith: the apex -eq test above is case-insensitive, and DNS
-        # names are case-insensitive, so the suffix test must be too (.EndsWith is a
-        # case-sensitive .NET call). Domain names contain no -like wildcard
-        # metacharacters, so $d is safe as the pattern. Same rule as the TransIP plugin.
-        if ($cleanName -eq $d -or $cleanName -like "*.$d") {
-            if (-not $best -or $d.Length -gt $best.Length) {
-                $best = $d
+    # We need to find the closest/deepest sub-zone that would hold
+    # the record rather than just adding it to the apex.
+    $pieces = $RecordName.Split('.')
+    for ($i=0; $i -lt ($pieces.Count-1); $i++) {
+        $zoneTest = $pieces[$i..($pieces.Count-1)] -join '.'
+        Write-Debug "Checking $zoneTest"
+
+        try {
+            $null = Invoke-HNLRest GET "domains/$zoneTest" $Token
+            # No error means the zone exists, so cache it and return it
+            # We don't need the save the ID because none of the other calls
+            # we'll be using need it.
+            Write-Debug "Cached zone $zoneTest for $RecordName"
+            $script:HNLRecordZones[$RecordName] = $zoneTest
+            return $zoneTest
+        } catch {
+            # 404 is expected if the zone doesn't exist. Re-throw any other error.
+            if ($_.Exception.StatusCode -eq 404) {
+                continue
+            } else {
+                Write-Debug "Error $($_.Exception.StatusCode)"
             }
+            throw
         }
     }
-    return $best
 
-    <#
-    .SYNOPSIS
-        Finds the account domain that owns a record name.
-
-    .DESCRIPTION
-        Lists the account's domains (paged) and returns the longest one that
-        equals, or is a parent of, RecordName. Returns $null when none matches.
-        The domain list is cached for the life of the loaded script.
-
-    .PARAMETER RecordName
-        The full record name to place, for example _acme-challenge.example.com.
-
-    .PARAMETER Token
-        The Hosting.nl API token, as plaintext.
-
-    .OUTPUTS
-        The owning domain name, or $null.
-    #>
+    # If we get here, we didn't find a matching zone.
+    throw "No zone in this account matches $RecordName"
 }

--- a/Posh-ACME/Plugins/HostingNL.ps1
+++ b/Posh-ACME/Plugins/HostingNL.ps1
@@ -1,0 +1,453 @@
+<#
+.SYNOPSIS
+    Posh-ACME DNS-01 plugin for Hosting.nl (api.hosting.nl)
+
+.DESCRIPTION
+    Uses the Hosting.nl REST API to manage TXT records for DNS-01 validation.
+    Auth is a single static header (API-TOKEN), no login/token-exchange step.
+
+.NOTES
+    API docs: https://api.hosting.nl/api/documentation
+    Reference client: lego's Hosting.nl provider (github.com/go-acme/lego,
+    providers/dns/hostingnl), used to confirm the wire format below since
+    Hosting.nl's own OpenAPI spec doesn't spell out the TXT quoting behavior.
+#>
+
+function Get-CurrentPluginType { 'dns-01' }
+
+function Add-DnsTxt {
+    [CmdletBinding(DefaultParameterSetName='Secure')]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position=1)]
+        [string]$TxtValue,
+        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [securestring]$HNLToken,
+        [Parameter(ParameterSetName='DeprecatedInsecure',Mandatory,Position=2)]
+        [string]$HNLTokenInsecure,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $RecordName = $RecordName.TrimEnd('.')
+
+    $token = if ($PSCmdlet.ParameterSetName -eq 'Secure') {
+        Unprotect-HNLSecureString -SecureString $HNLToken
+    } else {
+        $HNLTokenInsecure
+    }
+
+    $domain = Find-HNLZone -RecordName $RecordName -Token $token
+    if (-not $domain) {
+        throw "HostingNL: no domain in this account matches $RecordName"
+    }
+
+    $records = @((Invoke-HNLRest -Token $token -Method Get -Path "/domains/$domain/dns").data)
+
+    $already = $records | Where-Object {
+        $_.type -eq 'TXT' -and $_.name -eq $RecordName -and $_.content.Trim('"') -eq $TxtValue
+    }
+    if ($already) {
+        Write-Verbose "HostingNL: TXT record for $RecordName with this value already exists. Nothing to do."
+        return
+    }
+
+    # content is wrapped in literal double quotes to match lego's Hosting.nl
+    # provider, which sends strconv.Quote(value). Hosting.nl stores whatever
+    # is sent, quotes included, so a plugin that omits them writes a record
+    # that reads back differently than one lego wrote. Matching the quoting
+    # keeps Get-DnsTxt/Remove-DnsTxt comparisons correct either way.
+    $body = @(
+        @{
+            name    = $RecordName
+            type    = 'TXT'
+            content = ('"{0}"' -f $TxtValue)
+            ttl     = 300
+        }
+    )
+
+    $null = Invoke-HNLRest -Token $token -Method Post -Path "/domains/$domain/dns" -Body $body
+
+    <#
+    .SYNOPSIS
+        Add a DNS TXT record to Hosting.nl.
+
+    .DESCRIPTION
+        Finds the domain that owns RecordName, checks whether a matching TXT
+        record already exists, and if not, creates one via the Hosting.nl API.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER TxtValue
+        The value of the TXT record.
+
+    .PARAMETER HNLToken
+        The Hosting.nl API token, as a SecureString.
+
+    .PARAMETER HNLTokenInsecure
+        The Hosting.nl API token, as a plain string. Not recommended except
+        for testing or headless automation where SecureString isn't practical.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+
+    .EXAMPLE
+        $token = Read-Host 'HostingNL API Token' -AsSecureString
+        Add-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLToken $token
+
+        Adds the record using a SecureString token (recommended).
+
+    .EXAMPLE
+        Add-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLTokenInsecure 'my-api-token'
+
+        Adds the record using a plain-string token, for headless automation.
+    #>
+}
+
+function Remove-DnsTxt {
+    [CmdletBinding(DefaultParameterSetName='Secure')]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$RecordName,
+        [Parameter(Mandatory,Position=1)]
+        [string]$TxtValue,
+        [Parameter(ParameterSetName='Secure',Mandatory,Position=2)]
+        [securestring]$HNLToken,
+        [Parameter(ParameterSetName='DeprecatedInsecure',Mandatory,Position=2)]
+        [string]$HNLTokenInsecure,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $RecordName = $RecordName.TrimEnd('.')
+
+    $token = if ($PSCmdlet.ParameterSetName -eq 'Secure') {
+        Unprotect-HNLSecureString -SecureString $HNLToken
+    } else {
+        $HNLTokenInsecure
+    }
+
+    $domain = Find-HNLZone -RecordName $RecordName -Token $token
+    if (-not $domain) {
+        throw "HostingNL: no domain in this account matches $RecordName"
+    }
+
+    $records = @((Invoke-HNLRest -Token $token -Method Get -Path "/domains/$domain/dns").data)
+
+    $match = $records | Where-Object {
+        $_.type -eq 'TXT' -and $_.name -eq $RecordName -and $_.content.Trim('"') -eq $TxtValue
+    } | Select-Object -First 1
+
+    if (-not $match) {
+        Write-Verbose "HostingNL: TXT record for $RecordName with this value does not exist. Nothing to do."
+        return
+    }
+
+    $body = @(@{ id = $match.id })
+
+    $null = Invoke-HNLRest -Token $token -Method Delete -Path "/domains/$domain/dns" -Body $body
+
+    <#
+    .SYNOPSIS
+        Remove a DNS TXT record from Hosting.nl.
+
+    .DESCRIPTION
+        Finds the domain that owns RecordName, looks up the matching TXT
+        record by name and value, and deletes it by id via the Hosting.nl API.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER TxtValue
+        The value of the TXT record.
+
+    .PARAMETER HNLToken
+        The Hosting.nl API token, as a SecureString.
+
+    .PARAMETER HNLTokenInsecure
+        The Hosting.nl API token, as a plain string. Not recommended except
+        for testing or headless automation where SecureString isn't practical.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+
+    .EXAMPLE
+        $token = Read-Host 'HostingNL API Token' -AsSecureString
+        Remove-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLToken $token
+
+        Removes the record using a SecureString token (recommended).
+
+    .EXAMPLE
+        Remove-DnsTxt '_acme-challenge.example.com' 'txt-value' -HNLTokenInsecure 'my-api-token'
+
+        Removes the record using a plain-string token, for headless automation.
+    #>
+}
+
+function Save-DnsTxt {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+    <#
+    .SYNOPSIS
+        Not required.
+
+    .DESCRIPTION
+        Hosting.nl's add/delete endpoints apply immediately, so there is no
+        separate commit step.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    #>
+}
+
+function Get-DnsTxt {
+    [CmdletBinding(DefaultParameterSetName='Secure')]
+    param(
+        [Parameter(Mandatory,Position=0)]
+        [string]$RecordName,
+        [Parameter(ParameterSetName='Secure',Mandatory,Position=1)]
+        [securestring]$HNLToken,
+        [Parameter(ParameterSetName='DeprecatedInsecure',Mandatory,Position=1)]
+        [string]$HNLTokenInsecure,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $RecordName = $RecordName.TrimEnd('.')
+
+    $token = if ($PSCmdlet.ParameterSetName -eq 'Secure') {
+        Unprotect-HNLSecureString -SecureString $HNLToken
+    } else {
+        $HNLTokenInsecure
+    }
+
+    $domain = Find-HNLZone -RecordName $RecordName -Token $token
+    if (-not $domain) {
+        throw "HostingNL: no domain in this account matches $RecordName"
+    }
+
+    $records = @((Invoke-HNLRest -Token $token -Method Get -Path "/domains/$domain/dns").data)
+
+    $records |
+        Where-Object { $_.type -eq 'TXT' -and $_.name -eq $RecordName } |
+        ForEach-Object { $_.content.Trim('"') }
+
+    <#
+    .SYNOPSIS
+        Returns the TXT record values currently set for a given record name.
+
+    .DESCRIPTION
+        Finds the domain that owns RecordName and returns the (quote-stripped)
+        content of every TXT record at that name. Not called by Posh-ACME
+        itself; useful for manual verification against a live account.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER HNLToken
+        The Hosting.nl API token, as a SecureString.
+
+    .PARAMETER HNLTokenInsecure
+        The Hosting.nl API token, as a plain string. Not recommended except
+        for testing or headless automation where SecureString isn't practical.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+
+    .EXAMPLE
+        $token = Read-Host 'HostingNL API Token' -AsSecureString
+        Get-DnsTxt '_acme-challenge.example.com' -HNLToken $token
+    #>
+}
+
+############################
+# Helper Functions
+############################
+
+# API docs: https://api.hosting.nl/api/documentation
+
+$script:HNLApiRoot = 'https://api.hosting.nl'
+
+if (-not $script:HNLDomainCache) { $script:HNLDomainCache = $null }
+
+# Make sure TLS 1.2 is available for the api.hosting.nl calls. Posh-ACME
+# already sets this process-wide before a plugin loads; this only matters if
+# the file is dot-sourced standalone on Windows PowerShell 5.1, whose default
+# can still be TLS 1.0/1.1. OR it in rather than overwrite so we don't disable
+# protocols the host relies on; harmless no-op on PowerShell 7+.
+try {
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {
+    Write-Debug "HostingNL: could not set TLS 1.2 (likely already modern): $($_.Exception.Message)"
+}
+
+function Unprotect-HNLSecureString {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][securestring]$SecureString)
+    (New-Object System.Management.Automation.PSCredential('a', $SecureString)).GetNetworkCredential().Password
+
+    <#
+    .SYNOPSIS
+        Converts a SecureString to a plain string.
+
+    .DESCRIPTION
+        Returns the plaintext of a SecureString so it can be sent in the
+        API-TOKEN header. Uses the PSCredential round-trip, which works on both
+        Windows PowerShell 5.1 and PowerShell 7+.
+
+    .PARAMETER SecureString
+        The SecureString to convert.
+
+    .OUTPUTS
+        The plaintext string.
+    #>
+}
+
+# Wraps Invoke-RestMethod with the Hosting.nl auth header and error shape.
+# Hosting.nl reports errors as either {"error": "..."} or
+# {"errors": {"message": "..."}} in the response body rather than through
+# HTTP status text alone, so a plain Invoke-RestMethod failure would surface
+# a generic "400 Bad Request" instead of the actual reason. This pulls that
+# message out of the error response and rethrows it, falling back to the raw
+# error if the body doesn't match either shape.
+function Invoke-HNLRest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Token,
+        [Parameter(Mandatory)][string]$Method,
+        [Parameter(Mandatory)][string]$Path,
+        [object]$Body
+    )
+
+    $params = @{
+        Uri         = "$script:HNLApiRoot$Path"
+        Method      = $Method
+        Headers     = @{ 'API-TOKEN' = $Token; 'Accept' = 'application/json' }
+        ContentType = 'application/json'
+        ErrorAction = 'Stop'
+        Verbose     = $false
+    }
+    if ($PSBoundParameters.ContainsKey('Body')) {
+        # Pass -InputObject, not the pipeline. Piping a single-element array into
+        # ConvertTo-Json unrolls it and emits a JSON object ({...}); the API's
+        # add/delete endpoints require an array ([{...}]). -InputObject keeps the
+        # array shape for one or many records. Verified on PS 7 and WinPS 5.1.
+        $params.Body = (ConvertTo-Json -InputObject $Body -Depth 5)
+    }
+
+    try {
+        Write-Debug "$Method $($params.Uri)"
+        return Invoke-RestMethod @params @script:UseBasic
+    } catch {
+        $apiMessage = $null
+        $errResp = $_.ErrorDetails.Message
+        if ($errResp) {
+            try {
+                $parsed = $errResp | ConvertFrom-Json
+                if ($parsed.error) { $apiMessage = $parsed.error }
+                elseif ($parsed.errors.message) { $apiMessage = $parsed.errors.message }
+            } catch {
+                Write-Debug "HostingNL: error response body was not JSON: $errResp"
+            }
+        }
+        if ($apiMessage) {
+            throw "HostingNL: $Method $Path failed: $apiMessage"
+        }
+        throw
+    }
+
+    <#
+    .SYNOPSIS
+        Calls the Hosting.nl REST API.
+
+    .DESCRIPTION
+        Wraps Invoke-RestMethod with the API-TOKEN header and JSON content type,
+        serializes any body to a JSON array, and on failure rethrows the message
+        Hosting.nl returns in the response body instead of a generic HTTP status.
+
+    .PARAMETER Token
+        The Hosting.nl API token, as plaintext.
+
+    .PARAMETER Method
+        The HTTP method: Get, Post, or Delete.
+
+    .PARAMETER Path
+        The request path appended to https://api.hosting.nl, for example /domains.
+
+    .PARAMETER Body
+        Optional request body (a PowerShell object or array) sent as JSON.
+
+    .OUTPUTS
+        The parsed response object.
+    #>
+}
+
+# Pages through GET /domains (Hosting.nl caps the response per call, hence
+# limit/offset) and returns the longest domain name that owns RecordName,
+# the same "prefer the longest owned match" rule the TransIP plugin uses.
+# Needed here because an account can hold both a parent and a delegated
+# child zone. Results are cached per plugin invocation of the dot-sourced
+# script; Add/Remove/Get each get a fresh process from Posh-ACME per run.
+function Find-HNLZone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RecordName,
+        [Parameter(Mandatory)][string]$Token
+    )
+
+    # $null (not just falsy) means "not fetched yet": an account with zero domains
+    # caches as @(), which is falsy, so a -not guard would re-page every call.
+    if ($null -eq $script:HNLDomainCache) {
+        $limit = 100
+        $offset = 0
+        $all = @()
+        do {
+            $page = Invoke-HNLRest -Token $Token -Method Get -Path "/domains?limit=$limit&offset=$offset"
+            $pageData = @($page.data)
+            $all += $pageData
+            $offset += $limit
+        } while ($pageData.Count -ge $limit)
+
+        $script:HNLDomainCache = @($all | ForEach-Object { $_.domain } | Where-Object { $_ })
+    }
+
+    $cleanName = $RecordName.TrimEnd('.')
+    $best = $null
+    foreach ($d in $script:HNLDomainCache) {
+        # -like, not .EndsWith: the apex -eq test above is case-insensitive, and DNS
+        # names are case-insensitive, so the suffix test must be too (.EndsWith is a
+        # case-sensitive .NET call). Domain names contain no -like wildcard
+        # metacharacters, so $d is safe as the pattern. Same rule as the TransIP plugin.
+        if ($cleanName -eq $d -or $cleanName -like "*.$d") {
+            if (-not $best -or $d.Length -gt $best.Length) {
+                $best = $d
+            }
+        }
+    }
+    return $best
+
+    <#
+    .SYNOPSIS
+        Finds the account domain that owns a record name.
+
+    .DESCRIPTION
+        Lists the account's domains (paged) and returns the longest one that
+        equals, or is a parent of, RecordName. Returns $null when none matches.
+        The domain list is cached for the life of the loaded script.
+
+    .PARAMETER RecordName
+        The full record name to place, for example _acme-challenge.example.com.
+
+    .PARAMETER Token
+        The Hosting.nl API token, as plaintext.
+
+    .OUTPUTS
+        The owning domain name, or $null.
+    #>
+}

--- a/Posh-ACME/Private/Import-PluginDetail.ps1
+++ b/Posh-ACME/Private/Import-PluginDetail.ps1
@@ -51,6 +51,7 @@ function Import-PluginDetail {
         'HetznerCloud'         = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'HetznerCloud'}
         'HostUp'               = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'HostUp'}
         'HostingDe'            = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'HostingDe'}
+        'HostingNL'            = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'HostingNL'}
         'HurricaneElectric'    = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'HurricaneElectric'}
         'HurricaneElectricDyn' = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'HurricaneElectric'}
         'IBMSoftLayer'         = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'IBMSoftLayer'}

--- a/docs/Plugins/HostingNL.md
+++ b/docs/Plugins/HostingNL.md
@@ -1,0 +1,28 @@
+title: HostingNL
+
+# HostingNL
+
+This plugin works against the Hosting.nl REST API (`api.hosting.nl`) for accounts hosted with
+[Hosting.nl](https://www.hosting.nl/).
+
+## Setup
+
+Log in to the Hosting.nl control panel and navigate to the API settings.
+
+- Click `Generate New API Key`
+- Select `Domains Management (Only Read)` and `Domains Management (Only Write)`
+- Click `Generate Key`
+
+Store the resulting key value for use with the plugin.
+
+## Using the Plugin
+
+The key value you generated is used with the `HNLToken' parameter as a SecureString value.
+
+```powershell
+$pArgs = @{
+    HNLToken = (Read-Host 'Hosting.nl API Token' -AsSecureString)
+}
+
+New-PACertificate example.com -Plugin HostingNL -PluginArgs $pArgs
+```

--- a/docs/Plugins/index.md
+++ b/docs/Plugins/index.md
@@ -52,6 +52,7 @@ GoDaddy | [GoDaddy](https://www.godaddy.com) | [Usage Guide](GoDaddy.md) | :whit
 Hetzner | [Hetzner](https://hetzner.de/) (Deprecated) | [Usage Guide](Hetzner.md) | :white_check_mark:
 HetznerCloud | [Hetzner](https://hetzner.de/) | [Usage Guide](Hetzner.md) | :white_check_mark:
 HostingDe | [Hosting.de](https://hosting.de) | [Usage Guide](HostingDe.md) | :white_check_mark:
+HostingNL | [Hosting.nl](https://hosting.nl) | [Usage Guide](HostingNL.md) | :white_check_mark:
 HostUp | [HostUp](https://hostup.se) | [Usage Guide](HostUp.md) | :white_check_mark:
 HurricaneElectric | [Hurricane Electric DNS](https://dns.he.net/) | [Usage Guide](HurricaneElectric.md) | :white_check_mark:
 HurricaneElectricDyn | [Hurricane Electric DNS](https://dns.he.net/) | [Usage Guide](HurricaneElectricDyn.md) | :white_check_mark:


### PR DESCRIPTION
This plugin adds support for Hosting.nl API for DNS-01 validation.
I've not livetested this, I have used the lego acme client plugin and the API documentation as reference.