### PR TITLE
Regru: switch API calls from GET to POST with form-encoded body

### DIFF
--- a/Posh-ACME/Plugins/Regru.ps1
+++ b/Posh-ACME/Plugins/Regru.ps1
@@ -44,13 +44,20 @@ function Add-DnsTxt {
             text                = $TxtValue
             output_content_type = 'plain'
         }
-        $queryUri = '{0}add_txt?input_format=json&input_data={1}' -f $apiBase,(ConvertTo-RrBody $bodyParams)
+        $queryUri = '{0}add_txt' -f $apiBase
+        $formBody = @{
+            input_format = 'json'
+            input_data   = ($bodyParams | ConvertTo-Json -Compress -Depth 10)
+        }
         $bodyParams.password = 'XXXXXXXX'
-        $querySanitized = '{0}add_txt?input_format=json&input_data={1}' -f $apiBase,(ConvertTo-RrBody $bodyParams)
+        $sanitizedBody = @{
+            input_format = 'json'
+            input_data   = ($bodyParams | ConvertTo-Json -Compress -Depth 10)
+        }
 
         try {
-            Write-Debug "GET $querySanitized"
-            $response = Invoke-RestMethod $queryUri -EA Stop -Verbose:$false @script:UseBasic
+            Write-Debug "POST $queryUri body=$(($sanitizedBody | ConvertTo-Json -Compress))"
+            $response = Invoke-RestMethod $queryUri -Method Post -Body $formBody -EA Stop -Verbose:$false @script:UseBasic
             if ($response) { Write-Debug "Response:`n$(($response | ConvertTo-Json -Depth 10))" }
         }
         catch { throw }
@@ -67,10 +74,10 @@ function Add-DnsTxt {
 
     <#
      .SYNOPSIS
-        Remove a DNS TXT record from Reg.Ru.
+        Add a DNS TXT record to Reg.Ru.
 
     .DESCRIPTION
-        Uses the Reg.Ru API to remove a DNS TXT record.
+        Uses the Reg.Ru API to add a DNS TXT record.
 
     .PARAMETER RecordName
         The fully qualified name of the TXT record.
@@ -141,13 +148,20 @@ function Remove-DnsTxt {
             record_type         = 'TXT'
             output_content_type = 'plain'
         }
-        $queryUri = '{0}remove_record?input_format=json&input_data={1}' -f $apiBase,(ConvertTo-RrBody $bodyParams)
+        $queryUri = '{0}remove_record' -f $apiBase
+        $formBody = @{
+            input_format = 'json'
+            input_data   = ($bodyParams | ConvertTo-Json -Compress -Depth 10)
+        }
         $bodyParams.password = 'XXXXXXXX'
-        $querySanitized = '{0}remove_record?input_format=json&input_data={1}' -f $apiBase,(ConvertTo-RrBody $bodyParams)
+        $sanitizedBody = @{
+            input_format = 'json'
+            input_data   = ($bodyParams | ConvertTo-Json -Compress -Depth 10)
+        }
 
         try {
-            Write-Debug "GET $querySanitized"
-            $response = Invoke-RestMethod $queryUri -EA Stop -Verbose:$false @script:UseBasic
+            Write-Debug "POST $queryUri body=$(($sanitizedBody | ConvertTo-Json -Compress))"
+            $response = Invoke-RestMethod $queryUri -Method Post -Body $formBody -EA Stop -Verbose:$false @script:UseBasic
             if ($response) { Write-Debug "Response:`n$(($response | ConvertTo-Json -Depth 10))" }
         }
         catch { throw }
@@ -265,13 +279,20 @@ function Get-RrTxtRecord {
         domains             = $zoneTests
         output_content_type = 'plain'
     }
-    $queryUri = '{0}get_resource_records?input_format=json&input_data={1}' -f $apiBase,(ConvertTo-RrBody $bodyParams)
+    $queryUri = '{0}get_resource_records' -f $apiBase
+    $formBody = @{
+        input_format = 'json'
+        input_data   = ($bodyParams | ConvertTo-Json -Compress -Depth 10)
+    }
     $bodyParams.password = 'XXXXXXXX'
-    $querySanitized = '{0}get_resource_records?input_format=json&input_data={1}' -f $apiBase,(ConvertTo-RrBody $bodyParams)
+    $sanitizedBody = @{
+        input_format = 'json'
+        input_data   = ($bodyParams | ConvertTo-Json -Compress -Depth 10)
+    }
 
     try {
-        Write-Debug "GET $querySanitized"
-        $response = Invoke-RestMethod $queryUri -EA Stop -Verbose:$false @script:UseBasic
+        Write-Debug "POST $queryUri body=$(($sanitizedBody | ConvertTo-Json -Compress))"
+        $response = Invoke-RestMethod $queryUri -Method Post -Body $formBody -EA Stop -Verbose:$false @script:UseBasic
         if ($response) { Write-Debug "Response:`n$(($response | ConvertTo-Json -Depth 10))" }
     }
     catch { throw }


### PR DESCRIPTION
REG.RU API 2 rejects the current plugin behavior in two ways:

1. GET on zone/* endpoints returns: { "error_code": "ONLY_POST_ALLOWED", "error_text": "Only HTTP method POST allowed" }

2. POST with params in URL query string returns: { "error_code": "QUERY_PARAMS_DISALLOWED", "error_text": "Query string parameters are disallowed. Pass parameters in form data." }

Only POST with application/x-www-form-urlencoded body is accepted.

This change moves input_format/input_data from the URL query string into a POST body via Invoke-RestMethod -Method Post -Body @{...}. input_data is passed as raw JSON produced by ConvertTo-Json (not URL-escaped) - Invoke-RestMethod handles form-encoding automatically when given a hashtable in -Body, so wrapping the JSON in [uri]::EscapeDataString would cause double-encoding.

Also fixes the Add-DnsTxt SYNOPSIS/DESCRIPTION that was copy-pasted from Remove-DnsTxt.

Reference: the official acme.sh dns_regru.sh plugin uses POST with form-body for the same endpoints and is known-working.

Refs #589