### PR TITLE
Add InfomaniakV2 plugin for the Infomaniak v2 API

### DIFF
--- a/Posh-ACME/Plugins/InfomaniakV2.ps1
+++ b/Posh-ACME/Plugins/InfomaniakV2.ps1
@@ -1,0 +1,303 @@
+function Get-CurrentPluginType { 'dns-01' }
+
+function Add-DnsTxt {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$RecordName,
+        [Parameter(Mandatory, Position = 1)]
+        [string]$TxtValue,
+        [Parameter(Mandatory, Position = 2)]
+        [securestring]$InfomaniakToken,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $apiRoot = 'https://api.infomaniak.com/2/zones'
+
+    # grab the plain text token
+    $tokenPlain = [pscredential]::new('a',$InfomaniakToken).GetNetworkCredential().Password
+
+    # build the common parameters for all API calls
+    $commonParams = @{
+        Headers = @{
+            Authorization = "Bearer $tokenPlain"
+            Accept        = 'application/json'
+        }
+        ErrorAction = 'Stop'
+        Verbose = $false
+        Debug = $false
+    } + $script:UseBasic
+
+    if (-not ($zone = Find-IKV2Zone $RecordName $commonParams $apiRoot)) {
+        throw "Unable to find matching zone for $RecordName."
+    }
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.TrimEnd('.')))$",''
+    # the API represents an apex record with a bare dot
+    if ([String]::IsNullOrEmpty($recShort)) { $recShort = '.' }
+
+    if (Find-IKV2TxtRecord $zone $recShort $RecordName $TxtValue $commonParams $apiRoot) {
+        Write-Debug "Record $RecordName already contains $TxtValue. Nothing to do."
+        return
+    }
+
+    try {
+        Write-Verbose "Adding a TXT record for $RecordName with value $TxtValue"
+        $queryParams = @{
+            Uri = "$apiRoot/$zone/records"
+            Method = 'POST'
+            Body = @{
+                type   = 'TXT'
+                source = $recShort
+                target = $TxtValue
+                ttl    = 600
+            } | ConvertTo-Json -Compress
+            ContentType = 'application/json'
+        } + $commonParams
+        Write-Debug "POST $($queryParams.Uri)`n$($queryParams.Body)"
+        Invoke-RestMethod @queryParams | Out-Null
+    } catch { throw }
+
+    <#
+    .SYNOPSIS
+        Add a DNS TXT record to Infomaniak using their v2 API.
+
+    .DESCRIPTION
+        Add a DNS TXT record to Infomaniak using their v2 API.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER TxtValue
+        The value of the TXT record.
+
+    .PARAMETER InfomaniakToken
+        The API token for your Infomaniak account. It must have the 'dns:read' and 'dns:write' scopes.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+
+    .EXAMPLE
+        $token = Read-Host 'Token' -AsSecureString
+        Add-DnsTxt '_acme-challenge.example.com' 'txt-value' $token
+
+        Adds the specified TXT record with the specified value.
+    #>
+}
+
+function Remove-DnsTxt {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$RecordName,
+        [Parameter(Mandatory, Position = 1)]
+        [string]$TxtValue,
+        [Parameter(Mandatory, Position = 2)]
+        [securestring]$InfomaniakToken,
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+
+    $apiRoot = 'https://api.infomaniak.com/2/zones'
+
+    # grab the plain text token
+    $tokenPlain = [pscredential]::new('a',$InfomaniakToken).GetNetworkCredential().Password
+
+    # build the common parameters for all API calls
+    $commonParams = @{
+        Headers = @{
+            Authorization = "Bearer $tokenPlain"
+            Accept        = 'application/json'
+        }
+        ErrorAction = 'Stop'
+        Verbose = $false
+        Debug = $false
+    } + $script:UseBasic
+
+    if (-not ($zone = Find-IKV2Zone $RecordName $commonParams $apiRoot)) {
+        throw "Unable to find matching zone for $RecordName."
+    }
+
+    # separate the portion of the name that doesn't contain the zone name
+    $recShort = $RecordName -ireplace "\.?$([regex]::Escape($zone.TrimEnd('.')))$",''
+    # the API represents an apex record with a bare dot
+    if ([String]::IsNullOrEmpty($recShort)) { $recShort = '.' }
+
+    $rec = Find-IKV2TxtRecord $zone $recShort $RecordName $TxtValue $commonParams $apiRoot
+
+    if (-not $rec) {
+        Write-Debug "Could not find record $RecordName to delete. Nothing to do."
+        return
+    }
+
+    try {
+        Write-Verbose "Removing TXT record for $RecordName with value $TxtValue"
+        $queryParams = @{
+            Uri = "$apiRoot/$zone/records/$($rec.id)"
+            Method = 'DELETE'
+        } + $commonParams
+        Write-Debug "DELETE $($queryParams.Uri)"
+        Invoke-RestMethod @queryParams | Out-Null
+    } catch { throw }
+
+    <#
+    .SYNOPSIS
+        Remove a DNS TXT record from Infomaniak using their v2 API.
+
+    .DESCRIPTION
+        Remove a DNS TXT record from Infomaniak using their v2 API.
+
+    .PARAMETER RecordName
+        The fully qualified name of the TXT record.
+
+    .PARAMETER TxtValue
+        The value of the TXT record.
+
+    .PARAMETER InfomaniakToken
+        The API token for your Infomaniak account. It must have the 'dns:read' and 'dns:write' scopes.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+
+    .EXAMPLE
+        $token = Read-Host 'Token' -AsSecureString
+        Remove-DnsTxt '_acme-challenge.example.com' 'txt-value' $token
+
+        Removes the specified TXT record with the specified value.
+    #>
+}
+
+function Save-DnsTxt {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        $ExtraParams
+    )
+    <#
+    .SYNOPSIS
+        Not required.
+
+    .DESCRIPTION
+        This provider does not require calling this function to commit changes to DNS records.
+
+    .PARAMETER ExtraParams
+        This parameter can be ignored and is only used to prevent errors when splatting with more parameters than this function supports.
+    #>
+}
+
+############################
+# Helper Functions
+############################
+
+# API Docs: https://developer.infomaniak.com/docs/api/get/2/zones/{zone}/records
+
+function Find-IKV2Zone {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$RecordName,
+        [Parameter(Mandatory, Position = 1)]
+        [hashtable]$CommonParams,
+        [Parameter(Mandatory, Position = 2)]
+        [string]$ApiRoot
+    )
+
+    # setup a module variable to cache the record to zone mapping
+    # so it's quicker to find later
+    if (!$script:IKV2RecordZones) { $script:IKV2RecordZones = @{} }
+
+    # check for the record in the cache
+    if ($script:IKV2RecordZones.ContainsKey($RecordName)) {
+        return $script:IKV2RecordZones.$RecordName
+    }
+
+    # Unlike the v1 API, v2 addresses zones by name rather than by a numeric product ID,
+    # so we can ask about a candidate zone directly instead of searching the product list.
+    # We still need to find the closest/deepest sub-zone that would hold the record rather
+    # than just adding it to the apex.
+    $pieces = $RecordName.Split('.')
+    for ($i=0; $i -lt ($pieces.Count-1); $i++) {
+        $zoneTest = $pieces[$i..($pieces.Count-1)] -join '.'
+        Write-Debug "Checking $zoneTest"
+
+        try {
+            $queryParams = @{
+                Uri = "$ApiRoot/$zoneTest/exists"
+            } + $CommonParams
+            Write-Debug "GET $($queryParams.Uri)"
+            $response = Invoke-RestMethod @queryParams
+        } catch {
+            # A zone that isn't in the account returns 404 with an 'object_not_found'
+            # error body. Ignore those and re-throw anything else.
+            if ($_.Exception.Response.StatusCode -ne 404) {
+                throw
+            }
+            continue
+        }
+
+        if ($response.result -eq 'success' -and $response.data) {
+            $script:IKV2RecordZones.$RecordName = $zoneTest
+            return $zoneTest
+        }
+    }
+
+    return $null
+}
+
+function Find-IKV2TxtRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$Zone,
+        [Parameter(Mandatory, Position = 1)]
+        [string]$RecShort,
+        [Parameter(Mandatory, Position = 2)]
+        [string]$RecordName,
+        [Parameter(Mandatory, Position = 3)]
+        [string]$TxtValue,
+        [Parameter(Mandatory, Position = 4)]
+        [hashtable]$CommonParams,
+        [Parameter(Mandatory, Position = 5)]
+        [string]$ApiRoot
+    )
+
+    # 'with=idn' adds the source_idn field which holds the fully qualified record
+    # name. There is no equivalent target_idn field in v2, so the value comparison
+    # below has to be done against the raw target.
+    try {
+        $queryParams = @{
+            Uri = "$ApiRoot/$Zone/records?with=idn"
+        } + $CommonParams
+        Write-Debug "GET $($queryParams.Uri)"
+        $recs = @(Invoke-RestMethod @queryParams | Select-Object -ExpandProperty data)
+    } catch { throw }
+
+    $recs | Where-Object {
+        $_.type -eq 'TXT' -and
+        ($_.source -eq $RecShort -or $_.source_idn -eq $RecordName) -and
+        (ConvertFrom-IKV2TxtTarget $_.target) -eq $TxtValue
+    } | Select-Object -First 1
+}
+
+function ConvertFrom-IKV2TxtTarget {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Target
+    )
+
+    # The v2 API returns TXT targets wrapped in literal double quotes even when they
+    # were submitted without them. For example, submitting 'abc123' comes back as
+    # '"abc123"'. Strip a single matched pair so comparisons against the raw ACME
+    # TxtValue succeed. Without this, existing challenge records are never matched,
+    # which would leave stale TXT records behind on cleanup.
+    if ($Target.Length -ge 2 -and $Target.StartsWith('"') -and $Target.EndsWith('"')) {
+        return $Target.Substring(1, $Target.Length - 2)
+    }
+
+    return $Target
+}

--- a/Posh-ACME/Plugins/InfomaniakV2.ps1
+++ b/Posh-ACME/Plugins/InfomaniakV2.ps1
@@ -13,6 +13,14 @@ function Add-DnsTxt {
         $ExtraParams
     )
 
+    # dns-01 values arrive bare, but dns-persist-01 values arrive already wrapped in
+    # double quotes because they contain spaces. The API stores exactly one pair of
+    # quotes either way, so normalize the incoming value to the quoted form and compare
+    # against the stored target as-is.
+    if ($TxtValue -notmatch '^".*"$') {
+        $TxtValue = '"{0}"' -f $TxtValue
+    }
+
     $apiRoot = 'https://api.infomaniak.com/2/zones'
 
     # grab the plain text token
@@ -99,6 +107,14 @@ function Remove-DnsTxt {
         [Parameter(ValueFromRemainingArguments)]
         $ExtraParams
     )
+
+    # dns-01 values arrive bare, but dns-persist-01 values arrive already wrapped in
+    # double quotes because they contain spaces. The API stores exactly one pair of
+    # quotes either way, so normalize the incoming value to the quoted form and compare
+    # against the stored target as-is.
+    if ($TxtValue -notmatch '^".*"$') {
+        $TxtValue = '"{0}"' -f $TxtValue
+    }
 
     $apiRoot = 'https://api.infomaniak.com/2/zones'
 
@@ -263,9 +279,10 @@ function Find-IKV2TxtRecord {
         [string]$ApiRoot
     )
 
-    # 'with=idn' adds the source_idn field which holds the fully qualified record
-    # name. There is no equivalent target_idn field in v2, so the value comparison
-    # below has to be done against the raw target.
+    # 'with=idn' adds the source_idn field, which holds the fully qualified record name,
+    # so the name comparison below can match either the relative or the fully qualified
+    # form. Separately, the API always returns TXT targets wrapped in a single pair of
+    # double quotes, which is why callers normalize TxtValue to the quoted form first.
     try {
         $queryParams = @{
             Uri = "$ApiRoot/$Zone/records?with=idn"
@@ -277,27 +294,6 @@ function Find-IKV2TxtRecord {
     $recs | Where-Object {
         $_.type -eq 'TXT' -and
         ($_.source -eq $RecShort -or $_.source_idn -eq $RecordName) -and
-        (ConvertFrom-IKV2TxtTarget $_.target) -eq $TxtValue
+        $_.target -eq $TxtValue
     } | Select-Object -First 1
-}
-
-function ConvertFrom-IKV2TxtTarget {
-    [CmdletBinding()]
-    param(
-        [Parameter(Position = 0)]
-        [AllowNull()]
-        [AllowEmptyString()]
-        [string]$Target
-    )
-
-    # The v2 API returns TXT targets wrapped in literal double quotes even when they
-    # were submitted without them. For example, submitting 'abc123' comes back as
-    # '"abc123"'. Strip a single matched pair so comparisons against the raw ACME
-    # TxtValue succeed. Without this, existing challenge records are never matched,
-    # which would leave stale TXT records behind on cleanup.
-    if ($Target.Length -ge 2 -and $Target.StartsWith('"') -and $Target.EndsWith('"')) {
-        return $Target.Substring(1, $Target.Length - 2)
-    }
-
-    return $Target
 }

--- a/Posh-ACME/Private/Import-PluginDetail.ps1
+++ b/Posh-ACME/Private/Import-PluginDetail.ps1
@@ -57,6 +57,7 @@ function Import-PluginDetail {
         'IBMSoftLayer'         = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'IBMSoftLayer'}
         'Infoblox'             = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'Infoblox'}
         'Infomaniak'           = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'Infomaniak'}
+        'InfomaniakV2'         = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'InfomaniakV2'}
         'INWX'                 = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'INWX'}
         'IONOS'                = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'IONOS'}
         'ISPConfig'            = [pscustomobject]@{PSTypeName = 'PoshACME.PAPluginDetail'; ChallengeType = 'dns-01'; Path = ''; Name = 'ISPConfig'}

--- a/docs/Plugins/Infomaniak.md
+++ b/docs/Plugins/Infomaniak.md
@@ -2,7 +2,10 @@ title: Infomaniak
 
 # How To Use the Infomaniak DNS Plugin
 
-This plugin works against the [Infomaniak](https://www.infomaniak.com) DNS provider. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.
+This plugin works against the [Infomaniak](https://www.infomaniak.com) DNS provider using version 1 of their API. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.
+
+!!! note
+    Infomaniak now documents version 2 of their API, which is served by the [InfomaniakV2](InfomaniakV2.md) plugin. This plugin continues to work, but new deployments should prefer InfomaniakV2. Switching requires a new API token with the `dns:read` and `dns:write` scopes, because the v2 endpoints reject tokens that only carry the `Domain` scope this guide asks for.
 
 ## Setup
 

--- a/docs/Plugins/InfomaniakV2.md
+++ b/docs/Plugins/InfomaniakV2.md
@@ -1,0 +1,50 @@
+title: InfomaniakV2
+
+# How To Use the InfomaniakV2 DNS Plugin
+
+This plugin works against the [Infomaniak](https://www.infomaniak.com) DNS provider using version 2 of their API. It is assumed that you have already setup an account and created the DNS zone(s) you will be working against.
+
+!!! note
+    This plugin is a replacement for the older [Infomaniak](Infomaniak.md) plugin which uses version 1 of the API. Switching requires a new API token, because the v2 endpoints reject the `Domain` scope the old plugin uses. Existing orders keep working on the v1 plugin until you migrate them. See [Migrating from the v1 plugin](#migrating-from-the-v1-plugin) below.
+
+## Setup
+
+You will need to generate an API Token if you haven't already done so. Go to [Manage API tokens](https://manager.infomaniak.com/v3/0/api/dashboard) after logging in to the [Management Console](https://manager.infomaniak.com). Create a new token with the `dns:read` and `dns:write` scopes. Set the expiration time to your preference. Make a note of the token value as you'll need it later and won't be able to retrieve it after this point.
+
+Those two scopes are all the plugin needs. `dns:read` covers the zone lookup and record listing, `dns:write` covers creating and deleting the challenge record. No other scope is required.
+
+!!! note
+    If the token gets invalidated before a renewal is submitted, a new token has to be created and the order has to be updated.
+
+!!! warning
+    Infomaniak must be the authoritative DNS provider for the domain. If a domain is registered with Infomaniak but its nameservers point elsewhere, the API still returns a leftover zone holding old records, and the plugin will correctly refuse to use it with an "Unable to find matching zone" error. Use the plugin for whichever provider actually serves the zone instead.
+
+## Using the Plugin
+
+You will need to provide the API Token as a SecureString value to `InfomaniakToken`.
+
+```powershell
+$pArgs = @{
+    InfomaniakToken = (Read-Host "Infomaniak Token" -AsSecureString)
+}
+New-PACertificate example.com -Plugin InfomaniakV2 -PluginArgs $pArgs
+```
+
+## Migrating from the v1 plugin
+
+The v1 and v2 APIs use different token scopes. A token carrying only the legacy `Domain` scope that the v1 plugin uses is rejected by every v2 endpoint, so you must generate a new token with `dns:read` and `dns:write` before switching. The rejection looks like this:
+
+```json
+{"result":"error","error":{"code":"all_scopes","description":"This method require this specific scope: \"dns:read\""}}
+```
+
+A token with `dns:read` and `dns:write` also works against the v1 endpoints, so the one new token serves both this plugin and the v1 [Infomaniak](Infomaniak.md) plugin. You don't need to keep the old token around, and you can switch back to v1 if needed.
+
+Because both plugins use the same `InfomaniakToken` parameter name, migrating an existing order only requires changing the plugin name and supplying the new token.
+
+```powershell
+$pArgs = @{
+    InfomaniakToken = (Read-Host "Infomaniak Token" -AsSecureString)
+}
+Set-PAOrder example.com -Plugin InfomaniakV2 -PluginArgs $pArgs
+```

--- a/docs/Plugins/index.md
+++ b/docs/Plugins/index.md
@@ -59,6 +59,7 @@ HurricaneElectricDyn | [Hurricane Electric DNS](https://dns.he.net/) | [Usage Gu
 IBMSoftLayer | [IBM Cloud DNS](https://www.ibm.com/cloud/dns) | [Usage Guide](IBMSoftLayer.md) | :white_check_mark:
 Infoblox | [Infoblox NIOS](https://www.infoblox.com) | [Usage Guide](Infoblox.md) | :white_check_mark:
 Infomaniak | [Infomaniak](https://www.infomaniak.com) | [Usage Guide](Infomaniak.md) | :white_check_mark:
+InfomaniakV2 | [Infomaniak](https://www.infomaniak.com) | [Usage Guide](InfomaniakV2.md) | :white_check_mark:
 INWX | [INWX](https://www.inwx.de/) | [Usage Guide](INWX.md) | :white_check_mark:
 IONOS | [IONOS](https://www.ionos.de/) | [Usage Guide](IONOS.md) | :white_check_mark:
 ISPConfig | [ISPConfig](https://www.ispconfig.org/) | [Usage Guide](ISPConfig.md) | :white_check_mark:


### PR DESCRIPTION
Adds an `InfomaniakV2` plugin and guide for [Infomaniak](https://www.infomaniak.com)'s v2 API. I wrote the original Infomaniak plugin back in #309.

### Why a separate plugin instead of updating the existing one

The v2 endpoints need a token with `dns:read` and `dns:write`, and a token carrying only the `Domain` scope that the current guide asks for is rejected outright. Changing the existing plugin in place would break existing users' tokens at their next renewal, so I followed the GoDaddy/GoDaddyV3 pattern instead. Existing orders stay on the v1 plugin until the user explicitly migrates, and the guide documents how.

Happy to fold it into the existing plugin instead if you would rather. That is the main thing I would like your call on.

### Implementation notes

v2 addresses zones by name, so the v1 `/1/product` lookup and its numeric zone ID bookkeeping are gone. Zone detection uses `/2/zones/{zone}/exists`, which answers 404 for a zone outside the account rather than 200 with `false`, so the walk treats 404 as "keep looking".

`/2/zones/{zone}/exists` also returns `false` for a domain that is registered with Infomaniak but whose nameservers point elsewhere. The API still exposes a leftover zone full of old records in that case, so testing existence by listing records would happily write challenge records into a zone nobody queries. The guide warns about this.

### Testing

- Full challenge cycle (create, duplicate detection, delete, idempotent delete) against two separate Infomaniak hosted zones in the same account, using a token carrying only `dns:read` and `dns:write`. Both zones came back byte identical afterwards.
- Those two scopes are therefore necessary and sufficient. `domain:read` is not needed, because the plugin probes candidate zones by name rather than enumerating the account's domains.
- A token carrying only the legacy `Domain` scope is rejected by every v2 endpoint. A v2 scoped token also works against the v1 endpoints, so a single token covers both plugins.
- Zone walk verified at one, two, three and four labels below the zone apex, including that the API accepts and round trips multi label `source` values like `_acme-challenge.a.b`.
- End to end against Let's Encrypt staging: issued with `-Plugin Infomaniak`, migrated the order with `Set-PAOrder -Plugin InfomaniakV2`, then `Submit-Renewal` reissued the certificate with nothing left in the zone. Both plugins use the `InfomaniakToken` parameter name, so the stored plugin args carry across the switch unchanged, as long as the token already carries the v2 scopes. The whole sequence ran on a single `dns:read` plus `dns:write` token.
- `Invoke-Pester`: 301 passed, 0 failed on both Windows PowerShell 5.1 and PowerShell 7.4.2.

### Testing on your side

I know you prefer to test plugins yourself, and Infomaniak has no free tier or sandbox. The account I tested against hosts live business domains, so I would rather not hand out credentials to it.

What I can offer instead: run whatever test scenarios you want against my account and paste the full output, including any edge cases you want covered before merging.
